### PR TITLE
feat: support ESPHome-based firmware

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,3 +79,4 @@
 ## General Guidance
 - Do not modify or extend any part of the codebase unless it follows the above patterns and guidelines.
 - Always strive for clarity, maintainability, and consistency with existing code and user experience.
+- When modifying existing code, do not add wrappers or fallbacks for legacy behavior. Refactor all existing code to the new standard.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { ZWavePortManager } from "./lib/zwave";
-import { ESPPortManager } from "./lib/esp-utils";
+import { ZWavePortManager, ZWA2_DEVICE_FILTERS } from "./lib/zwave";
+import { ESPPortManager, ESP32_DEVICE_FILTERS } from "./lib/esp-utils";
 import ActionCard from "./components/ActionCard";
 import ActionCardsGrid from "./components/ActionCardsGrid";
 import Breadcrumb from "./components/Breadcrumb";
@@ -43,6 +43,64 @@ export default function App() {
 		}
 	};
 
+	const requestCombinedSerialPort = async (): Promise<{ success: boolean; deviceType?: 'zwa2' | 'esp32' | 'unknown'; needsBootloaderMode?: boolean }> => {
+		setConnectionState({ status: 'connecting', type: 'zwa2' });
+
+		// Close any pre-existing connection first
+		await handleDisconnect();
+
+		try {
+			// Request port with combined filters
+			const port = await navigator.serial.requestPort({
+				filters: [...ZWA2_DEVICE_FILTERS, ...ESP32_DEVICE_FILTERS],
+			});
+
+			if (!port) {
+				setConnectionState({ status: 'disconnected' });
+				return { success: false };
+			}
+
+			// Open the port
+			await port.open({ baudRate: 115200 });
+
+			// Detect device type based on VID/PID
+			const info = port.getInfo();
+			const vendorId = info.usbVendorId;
+			const productId = info.usbProductId;
+
+			// Check if it matches any ZWA-2 filters
+			const isZWA2 = ZWA2_DEVICE_FILTERS.some(
+				filter => filter.usbVendorId === vendorId && filter.usbProductId === productId
+			);
+
+			// Check if it matches any ESP32 filters
+			const isESP32 = ESP32_DEVICE_FILTERS.some(
+				filter => filter.usbVendorId === vendorId && filter.usbProductId === productId
+			);
+
+			let detectedType: 'zwa2' | 'esp32' | 'unknown' = 'unknown';
+			let connectionType: 'zwa2' | 'esp32' = 'zwa2'; // Default fallback
+			let needsBootloaderMode = false;
+
+			if (isZWA2) {
+				detectedType = 'zwa2';
+				connectionType = 'zwa2';
+				needsBootloaderMode = true; // ZWA-2 needs to enter bootloader mode
+			} else if (isESP32) {
+				detectedType = 'esp32';
+				connectionType = 'esp32';
+				needsBootloaderMode = false; // ESP32 is already in bootloader mode
+			}
+
+			setConnectionState({ status: 'connected', port, type: connectionType });
+			return { success: true, deviceType: detectedType, needsBootloaderMode };
+		} catch (error) {
+			console.error("Failed to connect to device:", error);
+			setConnectionState({ status: 'disconnected' });
+			return { success: false };
+		}
+	};
+
 	const requestESP32SerialPort = async (): Promise<boolean> => {
 		setConnectionState({ status: 'connecting', type: 'esp32' });
 
@@ -67,6 +125,7 @@ export default function App() {
 		connectionState,
 		requestZWA2SerialPort,
 		requestESP32SerialPort,
+		requestCombinedSerialPort,
 		onDisconnect: handleDisconnect,
 	});
 

--- a/src/components/Wizard.tsx
+++ b/src/components/Wizard.tsx
@@ -5,7 +5,7 @@ import Button from './Button';
 import type { ZWaveBinding } from '../lib/zwave';
 import { ZWaveBinding as ZWaveBindingClass } from '../lib/zwave';
 
-export type ConnectionState = 
+export type ConnectionState =
   | { status: 'disconnected' }
   | { status: 'connecting'; type: 'zwa2' | 'esp32' }
   | { status: 'connected'; port: SerialPort; type: 'zwa2' | 'esp32' };
@@ -14,6 +14,7 @@ export interface BaseWizardContext {
   connectionState: ConnectionState;
   requestZWA2SerialPort: () => Promise<boolean>;
   requestESP32SerialPort: () => Promise<boolean>;
+  requestCombinedSerialPort?: () => Promise<{ success: boolean; deviceType?: 'zwa2' | 'esp32' | 'unknown'; needsBootloaderMode?: boolean }>;
   onDisconnect?: () => Promise<void>;
 }
 

--- a/src/wizards/install-firmware/wizard.ts
+++ b/src/wizards/install-firmware/wizard.ts
@@ -153,7 +153,7 @@ async function handleInstallStepEntry(context: WizardContext<InstallFirmwareStat
 
 export const installFirmwareWizardConfig: WizardConfig<InstallFirmwareState> = {
 	id: "install",
-	title: "Install firmware",
+	title: "Install Z-Wave firmware",
 	description:
 		"Install the latest controller firmware on your ZWA-2.",
 	icon: CloudArrowDownIcon,

--- a/src/wizards/recover-adapter/SummaryStep.tsx
+++ b/src/wizards/recover-adapter/SummaryStep.tsx
@@ -56,7 +56,7 @@ function getRecoveryResult(state: RecoverAdapterState): RecoveryResult {
           <div>
             <p>Your ZWA-2 adapter is running an end device CLI firmware, which may cause it to appear unresponsive in Z-Wave controller applications.</p>
             <p className="mt-2">
-              <strong>Recommendation:</strong> Use the "Install Firmware" wizard to install the correct Z-Wave controller firmware.
+              <strong>Recommendation:</strong> Use the "Install Z-Wave firmware" wizard to install the correct Z-Wave controller firmware.
             </p>
           </div>
         )
@@ -94,7 +94,7 @@ function getRecoveryResult(state: RecoverAdapterState): RecoveryResult {
           <div>
             <p>Failed to download the latest firmware from the internet. This could be due to a network connectivity issue or the firmware repository being temporarily unavailable.</p>
             <p className="mt-2">
-              <strong>Suggestion:</strong> Check your internet connection and try again, or use the "Install Firmware" wizard to provide a custom firmware file.
+              <strong>Suggestion:</strong> Check your internet connection and try again, or use the "Install Z-Wave firmware" wizard to provide a custom firmware file.
             </p>
           </div>
         )
@@ -119,7 +119,7 @@ function getRecoveryResult(state: RecoverAdapterState): RecoveryResult {
         message: (
           <div>
             <p>Your ZWA-2 adapter is running an unknown firmware that is not recognized as a standard Z-Wave controller firmware.</p>
-            <p className="mt-2">If you want to use this adapter as a Z-Wave controller, please use the "Install Firmware" wizard to install the correct Z-Wave controller firmware.</p>
+            <p className="mt-2">If you want to use this adapter as a Z-Wave controller, please use the "Install Z-Wave firmware" wizard to install the correct Z-Wave controller firmware.</p>
           </div>
         )
       };

--- a/src/wizards/update-esp-firmware/ESPConnectStep.tsx
+++ b/src/wizards/update-esp-firmware/ESPConnectStep.tsx
@@ -1,0 +1,70 @@
+import { LinkIcon } from '@heroicons/react/24/outline';
+import { useEffect, useRef } from 'react';
+import type { WizardStepProps } from '../../components/Wizard';
+import type { UpdateESPFirmwareState } from './wizard';
+
+/**
+ * Connect step for ESP firmware wizard that follows the standard ConnectStep pattern
+ */
+export default function ESPConnectStep({ context }: WizardStepProps<UpdateESPFirmwareState>) {
+  const isConnected = context.connectionState.status === 'connected';
+  const serialPort = context.connectionState.status === 'connected' ? context.connectionState.port : null;
+
+  // Track previous serialPort value
+  const prevSerialPort = useRef<SerialPort | null>(serialPort);
+
+  // Custom request function that uses combined filters
+  const requestCombinedSerialPort = async (): Promise<void> => {
+    if (context.requestCombinedSerialPort) {
+      await context.requestCombinedSerialPort();
+    } else {
+      // Fallback to ZWA-2 connection if combined request is not available
+      await context.requestZWA2SerialPort();
+    }
+  };
+
+  useEffect(() => {
+    // Only trigger when serialPort transitions from null to non-null
+    if (!prevSerialPort.current && serialPort) {
+      context.autoNavigateToNext();
+    }
+    prevSerialPort.current = serialPort;
+  }, [serialPort, context]);
+
+  return (
+    <div className="text-center py-8">
+      <div className={`mb-4 ${isConnected ? 'text-green-600 dark:text-green-400' : 'text-gray-400 dark:text-gray-600'}`}>
+        <LinkIcon className="w-16 h-16 mx-auto" />
+      </div>
+      <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+        {isConnected ? 'ZWA-2 Connected' : 'Connect to ZWA-2'}
+      </h3>
+      <p className="text-gray-600 dark:text-gray-300 mb-6">
+        {isConnected
+          ? 'Successfully connected to your ZWA-2.'
+          : 'First, we need to establish a connection to your ZWA-2. Depending on the ESP firmware, the device will be called "ZWA-2", "ESP32-S3" or "USB JTAG/serial debug unit".'
+        }
+      </p>
+      {!isConnected && (
+        <button
+          onClick={requestCombinedSerialPort}
+          disabled={context.connectionState.status === 'connecting'}
+          className="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-indigo-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:hover:bg-indigo-400"
+        >
+          {context.connectionState.status === 'connecting' ? 'Connecting...' : 'Connect'}
+        </button>
+      )}
+      {isConnected && context.onDisconnect && (
+        <button
+          onClick={() => {
+            context.onDisconnect?.();
+            requestCombinedSerialPort();
+          }}
+          className="rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-xs inset-ring inset-ring-gray-300 hover:bg-gray-50 dark:bg-white/10 dark:text-white dark:shadow-none dark:inset-ring-white/5 dark:hover:bg-white/20"
+        >
+          Connect different device
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/wizards/update-esp-firmware/FileSelectStep.tsx
+++ b/src/wizards/update-esp-firmware/FileSelectStep.tsx
@@ -2,136 +2,172 @@ import { useCallback, useEffect, useState } from 'react';
 import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import type { WizardStepProps } from '../../components/Wizard';
 import type { UpdateESPFirmwareState, ESPFirmwareOption } from './wizard';
-import { fetchLatestESPFirmwareInfo } from '../../lib/esp-firmware-download';
+import { ESP_FIRMWARE_MANIFESTS } from './wizard';
+import { fetchManifestFirmwareInfo } from '../../lib/esp-firmware-download';
 import Modal from '../../components/Modal';
 
 export default function FileSelectStep({ context }: WizardStepProps<UpdateESPFirmwareState>) {
-  const { selectedFirmware, latestESPFirmwareInfo, isLoadingFirmwareInfo } = context.state;
+  const { selectedFirmware, manifestInfo, isLoadingManifestInfo } = context.state;
   const [isChangelogModalOpen, setIsChangelogModalOpen] = useState(false);
+  const [activeChangelogManifest, setActiveChangelogManifest] = useState<string | null>(null);
 
-  // Fetch release info when component mounts
+  // Fetch manifest info when component mounts
   useEffect(() => {
-    if (!latestESPFirmwareInfo && !isLoadingFirmwareInfo) {
-      context.setState(prev => ({ ...prev, isLoadingFirmwareInfo: true }));
+    if (!manifestInfo && !isLoadingManifestInfo) {
+      context.setState(prev => ({ ...prev, isLoadingManifestInfo: true }));
 
-      fetchLatestESPFirmwareInfo()
-        .then(info => {
+      // Fetch info for all manifests
+      const fetchPromises = Object.entries(ESP_FIRMWARE_MANIFESTS).map(([id, manifest]) =>
+        fetchManifestFirmwareInfo(manifest.manifestUrl, manifest.changelogUrl)
+          .then(info => ({ id, info }))
+          .catch(error => {
+            console.error(`Failed to fetch manifest info for ${id}:`, error);
+            return { id, info: null };
+          })
+      );
+
+      Promise.all(fetchPromises)
+        .then(results => {
+          const manifestInfoRecord: Record<string, any> = {};
+          results.forEach(({ id, info }) => {
+            if (info) {
+              manifestInfoRecord[id] = info;
+            }
+          });
+
           context.setState(prev => ({
             ...prev,
-            latestESPFirmwareInfo: info,
-            isLoadingFirmwareInfo: false,
+            manifestInfo: manifestInfoRecord,
+            isLoadingManifestInfo: false,
           }));
         })
         .catch(error => {
-          console.error('Failed to fetch ESP firmware info:', error);
+          console.error('Failed to fetch manifest info:', error);
           context.setState(prev => ({
             ...prev,
-            isLoadingFirmwareInfo: false,
+            isLoadingManifestInfo: false,
           }));
         });
     }
-  }, [context, latestESPFirmwareInfo, isLoadingFirmwareInfo]);
+  }, [context, manifestInfo, isLoadingManifestInfo]);
 
   const handleOptionChange = useCallback((option: ESPFirmwareOption) => {
-    // When selecting the latest option, store the actual version
-    if (option.type === "latest-esp" && latestESPFirmwareInfo) {
-      option.version = latestESPFirmwareInfo.version;
+    // When selecting a manifest option, store the actual version
+    if (option.type === "manifest" && manifestInfo?.[option.manifestId]) {
+      option.version = manifestInfo[option.manifestId].version;
     }
     context.setState(prev => ({ ...prev, selectedFirmware: option }));
-  }, [context, latestESPFirmwareInfo]);
+  }, [context, manifestInfo]);
 
   const isSelected = useCallback((option: ESPFirmwareOption) => {
-    return selectedFirmware?.type === option.type;
+    if (selectedFirmware?.type !== option.type) return false;
+    if (option.type === "manifest") {
+      return selectedFirmware.manifestId === option.manifestId;
+    }
+    return true;
   }, [selectedFirmware]);
 
-  const openChangelogModal = useCallback((e: React.MouseEvent) => {
+  const openChangelogModal = useCallback((e: React.MouseEvent, manifestId: string) => {
     e.stopPropagation();
     e.preventDefault();
+    setActiveChangelogManifest(manifestId);
     setIsChangelogModalOpen(true);
   }, []);
 
   const closeChangelogModal = useCallback(() => {
     setIsChangelogModalOpen(false);
+    setActiveChangelogManifest(null);
   }, []);
 
-  const firmwareOptions: Array<{ value: ESPFirmwareOption; label: string; description: string }> = [
-    {
-      value: { type: "latest-esp" },
-      label: "ESP bridge firmware (latest)",
-      description: "Download and install the latest official ESP bridge firmware from GitHub"
-    }
-  ];
+  const firmwareOptions: Array<{ value: ESPFirmwareOption; label: string; description: string; experimental?: boolean }> =
+    Object.entries(ESP_FIRMWARE_MANIFESTS).map(([id, manifest]) => ({
+      value: { type: "manifest", manifestId: id },
+      label: manifest.label,
+      description: manifest.description,
+      experimental: manifest.experimental,
+    }));
 
   return (
     <div className="py-8">
       <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-        Choose which ESP firmware package to install
+        Choose which firmware package to install
       </h3>
       <p className="text-gray-600 dark:text-gray-300 mb-6">
-        Select the ESP firmware package you want to install on your ZWA-2.
+        Select the firmware package you want to install on your ZWA-2.
       </p>
 
       <div className="space-y-4">
-        {firmwareOptions.map((option, index) => (
-          <div
-            key={index}
-            className={`relative flex items-start p-4 border rounded-lg cursor-pointer transition-colors ${
-              isSelected(option.value)
-                ? 'border-purple-500 bg-purple-50 dark:bg-purple-500/10 dark:border-purple-400'
-                : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
-            }`}
-            onClick={() => handleOptionChange(option.value)}
-          >
-            <div className="flex items-center h-5">
-              <input
-                type="radio"
-                name="espFirmwareOption"
-                checked={isSelected(option.value)}
-                onChange={() => handleOptionChange(option.value)}
-                className="h-4 w-4 text-purple-600 border-gray-300 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700"
-              />
-            </div>
-            <div className="ml-3 text-sm flex-1">
-              <div className="flex items-center gap-1 flex-wrap">
-                <label className="font-medium text-gray-900 dark:text-white cursor-pointer">
-                  {option.label}
-                </label>
-                {isLoadingFirmwareInfo && option.value.type === "latest-esp" && (
-                  <span className="text-gray-500 dark:text-gray-400">
-                    · Loading...
-                  </span>
-                )}
-                {latestESPFirmwareInfo && option.value.type === "latest-esp" && (
-                  <>
-                    <span className="text-gray-500 dark:text-gray-400">
-                      · {latestESPFirmwareInfo.version} ·
-                    </span>
-                    <button
-                      onClick={openChangelogModal}
-                      className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline"
-                    >
-                      changelog
-                    </button>
-                  </>
-                )}
+        {firmwareOptions.map((option, index) => {
+          const manifestId = option.value.manifestId;
+          const manifestData = manifestInfo?.[manifestId];
+          const isLoading = isLoadingManifestInfo && !manifestData;
+
+          return (
+            <div
+              key={index}
+              className={`relative flex items-start p-4 border rounded-lg cursor-pointer transition-colors ${
+                isSelected(option.value)
+                  ? 'border-purple-500 bg-purple-50 dark:bg-purple-500/10 dark:border-purple-400'
+                  : 'border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500'
+              }`}
+              onClick={() => handleOptionChange(option.value)}
+            >
+              <div className="flex items-center h-5">
+                <input
+                  type="radio"
+                  name="espFirmwareOption"
+                  checked={isSelected(option.value)}
+                  onChange={() => handleOptionChange(option.value)}
+                  className="h-4 w-4 text-purple-600 border-gray-300 focus:ring-purple-500 dark:border-gray-600 dark:bg-gray-700"
+                />
               </div>
-              <p className="text-gray-500 dark:text-gray-400 mt-1">
-                {option.description}
-              </p>
+              <div className="ml-3 text-sm flex-1">
+                <div className="flex items-center gap-1 flex-wrap">
+                  <label className="font-medium text-gray-900 dark:text-white cursor-pointer">
+                    {option.label}
+                  </label>
+                  {option.experimental && (
+                    <span className="inline-flex items-center px-2 py-1 rounded-md text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-400">
+                      Experimental
+                    </span>
+                  )}
+                  {isLoading && (
+                    <span className="text-gray-500 dark:text-gray-400">
+                      · Loading...
+                    </span>
+                  )}
+                  {manifestData && (
+                    <>
+                      <span className="text-gray-500 dark:text-gray-400">
+                        · {manifestData.version} ·
+                      </span>
+                      <button
+                        onClick={(e) => openChangelogModal(e, manifestId)}
+                        className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline"
+                      >
+                        changelog
+                      </button>
+                    </>
+                  )}
+                </div>
+                <p className="text-gray-500 dark:text-gray-400 mt-1">
+                  {option.description}
+                </p>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* Changelog Modal */}
       <Modal
         isOpen={isChangelogModalOpen}
         onClose={closeChangelogModal}
-        title={`Changelog · ${latestESPFirmwareInfo?.version || ''}`}
+        title={`Changelog · ${activeChangelogManifest && manifestInfo?.[activeChangelogManifest]?.version || ''}`}
         content={
           <div className="max-h-96 overflow-y-auto">
             <div className="whitespace-pre-wrap text-sm font-mono">
-              {latestESPFirmwareInfo?.changelog || 'No changelog available.'}
+              {activeChangelogManifest && manifestInfo?.[activeChangelogManifest]?.changelog || 'No changelog available.'}
             </div>
           </div>
         }

--- a/src/wizards/update-esp-firmware/InstallStep.tsx
+++ b/src/wizards/update-esp-firmware/InstallStep.tsx
@@ -1,6 +1,6 @@
 import type { WizardStepProps } from '../../components/Wizard';
 import type { UpdateESPFirmwareState } from './wizard';
-import { flashESPFirmware } from './wizard';
+import { flashESPFirmware, ESP_FIRMWARE_MANIFESTS } from './wizard';
 import CircularProgress from '../../components/CircularProgress';
 import { LinkIcon, LinkSlashIcon } from '@heroicons/react/24/outline';
 import { useEffect, useRef, useState } from 'react';
@@ -16,7 +16,7 @@ export default function InstallStep({ context }: WizardStepProps<UpdateESPFirmwa
     isEnteringBootloader,
     currentSubStep,
     selectedFirmware,
-    latestESPFirmwareInfo,
+    manifestInfo,
     bootloaderEntryFailed,
   } = context.state;
 
@@ -83,15 +83,21 @@ export default function InstallStep({ context }: WizardStepProps<UpdateESPFirmwa
 
   // Show indeterminate spinner if downloading
   if (isDownloading) {
+	const firmwareLabel = selectedFirmware?.type === "manifest" && ESP_FIRMWARE_MANIFESTS[selectedFirmware.manifestId]
+	  ? ESP_FIRMWARE_MANIFESTS[selectedFirmware.manifestId].label
+	  : undefined;
     return (
       <div className="text-center py-8">
         <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-purple-600 mx-auto mb-4"></div>
         <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
-          Download ESP firmware
+          {
+			firmwareLabel ? `Downloading ${firmwareLabel} firmware...` :
+			`Downloading firmware...`
+		  }
         </h3>
-        <p className="text-gray-600 dark:text-gray-300">
-          Downloading the latest ESP bridge firmware...
-        </p>
+        {/* <p className="text-gray-600 dark:text-gray-300">
+          Downloading firmware...
+        </p> */}
       </div>
     );
   }
@@ -199,11 +205,11 @@ export default function InstallStep({ context }: WizardStepProps<UpdateESPFirmwa
       <div className="text-center py-8">
         <CircularProgress progress={progress} className="mb-4" />
         <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
-          Update ESP firmware
+          Install firmware
         </h3>
         <p className="text-gray-600 dark:text-gray-300">
-          Installing {selectedFirmware?.type === "latest-esp" && latestESPFirmwareInfo
-            ? `ESP firmware ${latestESPFirmwareInfo.version}`
+          Installing {selectedFirmware?.type === "manifest" && manifestInfo?.[selectedFirmware.manifestId]
+            ? `${ESP_FIRMWARE_MANIFESTS[selectedFirmware.manifestId]?.label || 'firmware'} ${manifestInfo[selectedFirmware.manifestId].version}`
             : downloadedFirmwareName
           }...
         </p>
@@ -215,10 +221,10 @@ export default function InstallStep({ context }: WizardStepProps<UpdateESPFirmwa
   return (
     <div className="text-center py-8">
       <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-4">
-        Update ESP firmware
+        Install firmware
       </h3>
       <p className="text-gray-600 dark:text-gray-300">
-        Ready to update ESP firmware...
+        Ready to install firmware...
       </p>
     </div>
   );

--- a/src/wizards/update-esp-firmware/SummaryStep.tsx
+++ b/src/wizards/update-esp-firmware/SummaryStep.tsx
@@ -1,8 +1,9 @@
 import type { WizardStepProps } from '../../components/Wizard';
 import type { UpdateESPFirmwareState } from './wizard';
+import { ESP_FIRMWARE_MANIFESTS } from './wizard';
 
 export default function SummaryStep({ context }: WizardStepProps<UpdateESPFirmwareState>) {
-  const { installResult, errorMessage, currentESPVersion, latestESPFirmwareInfo } = context.state;
+  const { installResult, errorMessage, selectedFirmware } = context.state;
 
   const getResultContent = () => {
     switch (installResult) {
@@ -17,32 +18,16 @@ export default function SummaryStep({ context }: WizardStepProps<UpdateESPFirmwa
           ),
           title: "ESP firmware updated successfully!",
           message: (
-            <p className="text-gray-600 dark:text-gray-300">
-              Please power-cycle your ZWA-2 now to start the new firmware.
-            </p>
-          )
-        };
-
-      case "no-update-needed":
-        return {
-          icon: (
-            <div className="text-blue-600 dark:text-blue-400 mb-4">
-              <svg className="w-16 h-16 mx-auto" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-              </svg>
-            </div>
-          ),
-          title: "Already up to date!",
-          message: (
             <div>
-              <p className="text-gray-600 dark:text-gray-300 mb-2">
-                The ESP in your ZWA-2 is already running the latest firmware (or newer).
+              <p className="text-gray-600 dark:text-gray-300">
+                {selectedFirmware?.type === "manifest" && ESP_FIRMWARE_MANIFESTS[selectedFirmware.manifestId]
+                  ? `${ESP_FIRMWARE_MANIFESTS[selectedFirmware.manifestId].label} has been installed successfully.`
+                  : "The firmware has been installed successfully."
+                }
               </p>
-              {currentESPVersion && latestESPFirmwareInfo && (
-                <p className="text-sm text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 p-3 rounded">
-                  Current version: {currentESPVersion} (latest: {latestESPFirmwareInfo.version})
-                </p>
-              )}
+              <p className="text-gray-600 dark:text-gray-300 mt-2">
+                Please power-cycle your ZWA-2 now to start the new firmware.
+              </p>
             </div>
           )
         };


### PR DESCRIPTION
This PR adds support downloading ESPHome firmware manifests, install the firmware from them and enables the "Update ESP firmware" step to deal with the different states the ESP might be in.