### PR TITLE
Expose "Install ESP firmware" wizards as separate web components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
 				"prettier": "^3.6.2",
 				"react": "^19.1.1",
 				"react-dom": "^19.1.1",
+				"react-to-webcomponent": "^2.0.1",
 				"tailwindcss": "^4.1.12",
 				"typescript": "^5.9.2",
 				"typescript-eslint": "^8.41.0",
@@ -1950,6 +1951,13 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/@r2wc/core": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@r2wc/core/-/core-1.3.0.tgz",
+			"integrity": "sha512-aPBnND92Itl+SWWbWyyxdFFF0+RqKB6dptGHEdiPB8ZvnHWHlVzOfEvbEcyUYGtB6HBdsfkVuBiaGYyBFVTzVQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@react-aria/focus": {
 			"version": "3.21.1",
@@ -5860,6 +5868,20 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-to-webcomponent": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/react-to-webcomponent/-/react-to-webcomponent-2.0.1.tgz",
+			"integrity": "sha512-jpVztcA0SbV6TnBRV6EFuU+hmuuSIxgEww3wRcbneT0ytqn57y9ygeRfUmhzz8+bYg53u1h4COKk8iAextHE+Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@r2wc/core": "^1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
 		"prettier": "^3.6.2",
 		"react": "^19.1.1",
 		"react-dom": "^19.1.1",
+		"react-to-webcomponent": "^2.0.1",
 		"tailwindcss": "^4.1.12",
 		"typescript": "^5.9.2",
 		"typescript-eslint": "^8.41.0",

--- a/public/test-install-esp-bridge.html
+++ b/public/test-install-esp-bridge.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Install ESP Bridge Firmware</title>
+	</head>
+	<body>
+		<!-- The web component will be rendered here -->
+		<install-esp-bridge-firmware></install-esp-bridge-firmware>
+
+		<!-- Load the web component script -->
+		<script type="module" src="./standalone/install-esp-bridge-firmware.js"></script>
+	</body>
+</html>

--- a/public/test-install-esphome.html
+++ b/public/test-install-esphome.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Install ESPHome Firmware</title>
+	</head>
+	<body>
+		<!-- The web component will be rendered here -->
+		<install-esphome-firmware></install-esphome-firmware>
+
+		<!-- Load the web component script -->
+		<script
+			type="module"
+			src="./standalone/install-esphome-firmware.js"
+		></script>
+	</body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,137 +1,22 @@
 import { useState } from "react";
-import { ZWavePortManager, ZWA2_DEVICE_FILTERS } from "./lib/zwave";
-import { ESPPortManager, ESP32_DEVICE_FILTERS } from "./lib/esp-utils";
 import ActionCard from "./components/ActionCard";
 import ActionCardsGrid from "./components/ActionCardsGrid";
 import Breadcrumb from "./components/Breadcrumb";
 import WebSerialWarning from "./components/WebSerialWarning";
 import Wizard from "./components/Wizard";
-import type { BaseWizardContext, ConnectionState } from "./components/Wizard";
 import { wizards, type WizardId } from "./wizards";
+import { useBaseWizardContext } from "./hooks/useBaseWizardContext";
 
 export default function App() {
-	const [connectionState, setConnectionState] = useState<ConnectionState>({
-		status: 'disconnected',
-	});
 	const [activeWizard, setActiveWizard] = useState<WizardId | null>(null);
-
-	const handleDisconnect = async () => {
-		try {
-			if (connectionState.status === 'connected' && connectionState.port.connected && connectionState.port.readable) {
-				await connectionState.port.close();
-			}
-		} catch (error) {
-			console.error("Error during disconnect:", error);
-		} finally {
-			setConnectionState({ status: 'disconnected' });
-		}
-	};
-
-	const requestZWA2SerialPort = async (): Promise<boolean> => {
-		setConnectionState({ status: 'connecting', type: 'zwa2' });
-
-		// Close any pre-existing connection first
-		await handleDisconnect();
-
-		const port = await ZWavePortManager.requestPort();
-		if (port) {
-			setConnectionState({ status: 'connected', port, type: 'zwa2' });
-			return true;
-		} else {
-			setConnectionState({ status: 'disconnected' });
-			return false;
-		}
-	};
-
-	const requestCombinedSerialPort = async (): Promise<{ success: boolean; deviceType?: 'zwa2' | 'esp32' | 'unknown'; needsBootloaderMode?: boolean }> => {
-		setConnectionState({ status: 'connecting', type: 'zwa2' });
-
-		// Close any pre-existing connection first
-		await handleDisconnect();
-
-		try {
-			// Request port with combined filters
-			const port = await navigator.serial.requestPort({
-				filters: [...ZWA2_DEVICE_FILTERS, ...ESP32_DEVICE_FILTERS],
-			});
-
-			if (!port) {
-				setConnectionState({ status: 'disconnected' });
-				return { success: false };
-			}
-
-			// Open the port
-			await port.open({ baudRate: 115200 });
-
-			// Detect device type based on VID/PID
-			const info = port.getInfo();
-			const vendorId = info.usbVendorId;
-			const productId = info.usbProductId;
-
-			// Check if it matches any ZWA-2 filters
-			const isZWA2 = ZWA2_DEVICE_FILTERS.some(
-				filter => filter.usbVendorId === vendorId && filter.usbProductId === productId
-			);
-
-			// Check if it matches any ESP32 filters
-			const isESP32 = ESP32_DEVICE_FILTERS.some(
-				filter => filter.usbVendorId === vendorId && filter.usbProductId === productId
-			);
-
-			let detectedType: 'zwa2' | 'esp32' | 'unknown' = 'unknown';
-			let connectionType: 'zwa2' | 'esp32' = 'zwa2'; // Default fallback
-			let needsBootloaderMode = false;
-
-			if (isZWA2) {
-				detectedType = 'zwa2';
-				connectionType = 'zwa2';
-				needsBootloaderMode = true; // ZWA-2 needs to enter bootloader mode
-			} else if (isESP32) {
-				detectedType = 'esp32';
-				connectionType = 'esp32';
-				needsBootloaderMode = false; // ESP32 is already in bootloader mode
-			}
-
-			setConnectionState({ status: 'connected', port, type: connectionType });
-			return { success: true, deviceType: detectedType, needsBootloaderMode };
-		} catch (error) {
-			console.error("Failed to connect to device:", error);
-			setConnectionState({ status: 'disconnected' });
-			return { success: false };
-		}
-	};
-
-	const requestESP32SerialPort = async (): Promise<boolean> => {
-		setConnectionState({ status: 'connecting', type: 'esp32' });
-
-		// Close any pre-existing connection first
-		await handleDisconnect();
-
-		const port = await ESPPortManager.requestPort();
-		if (port) {
-			setConnectionState({ status: 'connected', port, type: 'esp32' });
-			return true;
-		} else {
-			setConnectionState({ status: 'disconnected' });
-			return false;
-		}
-	};
+	const baseContext = useBaseWizardContext();
 
 	const handleCloseWizard = () => {
 		setActiveWizard(null);
 	};
 
-	const createBaseWizardContext = (): BaseWizardContext => ({
-		connectionState,
-		requestZWA2SerialPort,
-		requestESP32SerialPort,
-		requestCombinedSerialPort,
-		onDisconnect: handleDisconnect,
-	});
-
 	// Render active wizard
 	if (activeWizard) {
-		const baseContext = createBaseWizardContext();
 
 		// Find the wizard configuration by ID
 		const currentWizard = wizards.find(
@@ -153,7 +38,7 @@ export default function App() {
 						<Breadcrumb
 							items={breadcrumbItems}
 							onHomeClick={handleCloseWizard}
-							disabled={connectionState.status === 'connecting'}
+							disabled={baseContext.connectionState.status === 'connecting'}
 						/>
 
 						<div className="mt-8">

--- a/src/components/Wizard.tsx
+++ b/src/components/Wizard.tsx
@@ -62,6 +62,7 @@ export interface WizardConfig<T = unknown> {
   iconBackground: string;
   steps: WizardStepConfig<T>[];
   createInitialState: () => T;
+  standalone?: boolean;
 }
 
 interface WizardProps<T = unknown> {
@@ -275,9 +276,10 @@ export default function Wizard<T = unknown>({ config, baseContext, onClose }: Wi
   const backButton = currentStep.navigationButtons?.back;
   const cancelButton = currentStep.navigationButtons?.cancel;
 
-  const showNext = nextButton !== undefined;
+  // Hide finish and cancel button on standalone wizards
+  const showNext = nextButton !== undefined && !(config.standalone && currentStep.isFinal);
   const showBack = !isFirstStep && backButton !== undefined && !currentStep.isFinal;
-  const showCancel = cancelButton !== undefined && !currentStep.isFinal;
+  const showCancel = cancelButton !== undefined && !currentStep.isFinal && !config.standalone;
 
   const nextDisabled = nextButton?.disabled?.(context) ?? false;
   const backDisabled = backButton?.disabled?.(context) ?? false;

--- a/src/hooks/useBaseWizardContext.ts
+++ b/src/hooks/useBaseWizardContext.ts
@@ -1,0 +1,126 @@
+import { useState, useCallback } from 'react';
+import type { BaseWizardContext, ConnectionState } from '../components/Wizard';
+import { ZWavePortManager, ZWA2_DEVICE_FILTERS } from '../lib/zwave';
+import { ESPPortManager, ESP32_DEVICE_FILTERS } from '../lib/esp-utils';
+
+/**
+ * Custom hook for managing serial port connections and creating the base wizard context.
+ * Handles connection state, port requests for ZWA-2 and ESP32 devices, and disconnection.
+ *
+ * @returns BaseWizardContext object with connection state and port request handlers
+ */
+export function useBaseWizardContext(): BaseWizardContext {
+	const [connectionState, setConnectionState] = useState<ConnectionState>({
+		status: 'disconnected',
+	});
+
+	const handleDisconnect = useCallback(async () => {
+		try {
+			if (connectionState.status === 'connected' && connectionState.port.connected && connectionState.port.readable) {
+				await connectionState.port.close();
+			}
+		} catch (error) {
+			console.error("Error during disconnect:", error);
+		} finally {
+			setConnectionState({ status: 'disconnected' });
+		}
+	}, [connectionState]);
+
+	const requestZWA2SerialPort = useCallback(async (): Promise<boolean> => {
+		setConnectionState({ status: 'connecting', type: 'zwa2' });
+
+		// Close any pre-existing connection first
+		await handleDisconnect();
+
+		const port = await ZWavePortManager.requestPort();
+		if (port) {
+			setConnectionState({ status: 'connected', port, type: 'zwa2' });
+			return true;
+		} else {
+			setConnectionState({ status: 'disconnected' });
+			return false;
+		}
+	}, [handleDisconnect]);
+
+	const requestESP32SerialPort = useCallback(async (): Promise<boolean> => {
+		setConnectionState({ status: 'connecting', type: 'esp32' });
+
+		// Close any pre-existing connection first
+		await handleDisconnect();
+
+		const port = await ESPPortManager.requestPort();
+		if (port) {
+			setConnectionState({ status: 'connected', port, type: 'esp32' });
+			return true;
+		} else {
+			setConnectionState({ status: 'disconnected' });
+			return false;
+		}
+	}, [handleDisconnect]);
+
+	const requestCombinedSerialPort = useCallback(async (): Promise<{ success: boolean; deviceType?: 'zwa2' | 'esp32' | 'unknown'; needsBootloaderMode?: boolean }> => {
+		setConnectionState({ status: 'connecting', type: 'zwa2' });
+
+		// Close any pre-existing connection first
+		await handleDisconnect();
+
+		try {
+			// Request port with combined filters
+			const port = await navigator.serial.requestPort({
+				filters: [...ZWA2_DEVICE_FILTERS, ...ESP32_DEVICE_FILTERS],
+			});
+
+			if (!port) {
+				setConnectionState({ status: 'disconnected' });
+				return { success: false };
+			}
+
+			// Open the port
+			await port.open({ baudRate: 115200 });
+
+			// Detect device type based on VID/PID
+			const info = port.getInfo();
+			const vendorId = info.usbVendorId;
+			const productId = info.usbProductId;
+
+			// Check if it matches any ZWA-2 filters
+			const isZWA2 = ZWA2_DEVICE_FILTERS.some(
+				filter => filter.usbVendorId === vendorId && filter.usbProductId === productId
+			);
+
+			// Check if it matches any ESP32 filters
+			const isESP32 = ESP32_DEVICE_FILTERS.some(
+				filter => filter.usbVendorId === vendorId && filter.usbProductId === productId
+			);
+
+			let detectedType: 'zwa2' | 'esp32' | 'unknown' = 'unknown';
+			let connectionType: 'zwa2' | 'esp32' = 'zwa2'; // Default fallback
+			let needsBootloaderMode = false;
+
+			if (isZWA2) {
+				detectedType = 'zwa2';
+				connectionType = 'zwa2';
+				needsBootloaderMode = true; // ZWA-2 needs to enter bootloader mode
+			} else if (isESP32) {
+				detectedType = 'esp32';
+				connectionType = 'esp32';
+				needsBootloaderMode = false; // ESP32 is already in bootloader mode
+			}
+
+			setConnectionState({ status: 'connected', port, type: connectionType });
+			return { success: true, deviceType: detectedType, needsBootloaderMode };
+		} catch (error) {
+			console.error("Failed to connect to device:", error);
+			setConnectionState({ status: 'disconnected' });
+			return { success: false };
+		}
+	}, [handleDisconnect]);
+
+	return {
+		connectionState,
+		requestZWA2SerialPort,
+		requestESP32SerialPort,
+		requestCombinedSerialPort,
+		onDisconnect: handleDisconnect,
+	};
+}

--- a/src/standalone/README.md
+++ b/src/standalone/README.md
@@ -1,0 +1,157 @@
+# Standalone Web Components
+
+This directory contains standalone web component entry points that can be used independently in other projects.
+
+## Available Components
+
+### 1. Update ESP Bridge Wizard (`update-esp-bridge-wizard`)
+
+Installs the USB Bridge firmware (default firmware) on the ZWA-2 device.
+
+**Web Component Tag:** `<update-esp-bridge-wizard></update-esp-bridge-wizard>`
+
+**Features:**
+- Auto-selects USB Bridge firmware
+- Simplified wizard flow (Connect → Install → Summary)
+- No firmware selection step needed
+
+### 2. Update ESPHome Wizard (`update-esp-home-wizard`)
+
+Installs the Portable Z-Wave (ESPHome) firmware on the ZWA-2 device to enable WiFi connectivity.
+
+**Web Component Tag:** `<update-esp-home-wizard></update-esp-home-wizard>`
+
+**Features:**
+- Auto-selects Portable Z-Wave firmware
+- Includes WiFi configuration step
+- Full wizard flow (Connect → Install → Configure WiFi → Summary)
+
+## Building the Components
+
+To build the standalone web components, run:
+
+```bash
+npm run build
+```
+
+This will generate:
+- `dist/standalone/update-esp-bridge.js` - USB Bridge wizard component
+- `dist/standalone/update-esp-home.js` - Portable Z-Wave wizard component
+
+## Usage in Other Projects
+
+### Step 1: Copy the built files
+
+After building, copy the generated JavaScript files from `dist/standalone/` to your project.
+
+### Step 2: Include in your HTML
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>My Project</title>
+	<!-- Load the Inter font (recommended) -->
+	<link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
+	<!-- Load the Tailwind CSS styles (required) -->
+	<link rel="stylesheet" href="path/to/assets/index-[hash].css" />
+</head>
+<body>
+	<!-- Use the web component -->
+	<update-esp-bridge-wizard></update-esp-bridge-wizard>
+	
+	<!-- Load the component script -->
+	<script type="module" src="path/to/standalone/update-esp-bridge.js"></script>
+</body>
+</html>
+```
+
+**Important:** You must include both the CSS file and the JS file. The CSS file contains all the Tailwind styles needed for the component to display correctly. The filename includes a hash (e.g., `index-j5xmVKn3.css`) which changes with each build.
+
+### Step 3 (Optional): Style the component
+
+The components include their own styles (Tailwind CSS), but you can wrap them in a container for additional styling:
+
+```html
+<div class="my-custom-wrapper">
+	<update-esp-bridge-wizard></update-esp-bridge-wizard>
+</div>
+```
+
+## Testing
+
+Test pages are available at:
+- `/test-esp-bridge.html` - Test USB Bridge wizard
+- `/test-esp-home.html` - Test Portable Z-Wave wizard
+
+To test locally:
+
+```bash
+npm run dev
+```
+
+Then navigate to:
+- http://localhost:5173/test-esp-bridge.html
+- http://localhost:5173/test-esp-home.html
+
+## Browser Requirements
+
+These components require browsers with Web Serial API support:
+- Chrome/Chromium 89+
+- Edge 89+
+- Opera 75+
+
+Web Serial API is **not supported** in Firefox or Safari.
+
+## Technical Details
+
+### Architecture
+
+The standalone components are built using:
+- **React** - UI framework
+- **react-to-webcomponent** - Converts React components to web components
+- **Tailwind CSS** - Styling
+- **Web Serial API** - Hardware communication
+- **esptool-js** - ESP32 firmware flashing
+- **improv-wifi-serial-sdk** - WiFi configuration (ESPHome only)
+
+### Component Structure
+
+Each standalone component:
+1. Manages its own connection state
+2. Provides serial port request handlers (ZWA-2 and ESP32)
+3. Renders the wizard with pre-configured settings
+4. Handles disconnection and cleanup
+
+### Customization
+
+The wizard configurations are defined in `src/wizards/update-esp-firmware/wizard.ts`:
+- `updateESPBridgeWizardConfig` - USB Bridge wizard
+- `updateESPHomeWizardConfig` - Portable Z-Wave wizard
+
+Both configurations have `standalone: true` to indicate they're designed for standalone use.
+
+## Troubleshooting
+
+### Component doesn't render
+
+- Ensure the script is loaded as a module: `<script type="module" ...>`
+- Check browser console for errors
+- Verify the browser supports Web Serial API
+
+### Serial port access denied
+
+- Web Serial API requires a secure context (HTTPS or localhost)
+- The user must trigger the port selection (e.g., via button click)
+
+### Styling issues
+
+- The component includes its own Tailwind CSS styles
+- If styles conflict, wrap the component in an isolated container
+- Consider using Shadow DOM for full style isolation (requires modification)
+
+## License
+
+Same as the main project.

--- a/src/standalone/install-esp-bridge-firmware.tsx
+++ b/src/standalone/install-esp-bridge-firmware.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import r2wc from "react-to-webcomponent";
+import Wizard from "../components/Wizard";
+import { updateESPBridgeWizardConfig } from "../wizards/update-esp-firmware";
+import { useBaseWizardContext } from "../hooks/useBaseWizardContext";
+import styles from "../index.css?inline";
+
+function InstallESPBridgeFirmwareWizard() {
+	const baseContext = useBaseWizardContext();
+
+	return (
+		<>
+			<style>{styles}</style>
+			<div className="min-h-screen bg-gray-100 dark:bg-gray-900 py-8 px-4">
+				<div className="max-w-4xl mx-auto">
+					<Wizard
+						config={updateESPBridgeWizardConfig}
+						baseContext={baseContext}
+					/>
+				</div>
+			</div>
+		</>
+	);
+}
+
+// Convert the React component to a web component
+const InstallESPBridgeFirmwareWebComponent = r2wc(
+	InstallESPBridgeFirmwareWizard,
+	React,
+	ReactDOM,
+);
+
+// Register the web component
+customElements.define("install-esp-bridge-firmware", InstallESPBridgeFirmwareWebComponent);
+
+export default InstallESPBridgeFirmwareWizard;

--- a/src/standalone/install-esphome-firmware.tsx
+++ b/src/standalone/install-esphome-firmware.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import r2wc from "react-to-webcomponent";
+import Wizard from "../components/Wizard";
+import { updateESPHomeWizardConfig } from "../wizards/update-esp-firmware";
+import { useBaseWizardContext } from "../hooks/useBaseWizardContext";
+import styles from "../index.css?inline";
+
+function InstallESPHomeFirmwareWizard() {
+	const baseContext = useBaseWizardContext();
+
+	return (
+		<>
+			<style>{styles}</style>
+			<div className="min-h-screen bg-gray-100 dark:bg-gray-900 py-8 px-4">
+				<div className="max-w-4xl mx-auto">
+					<Wizard
+						config={updateESPHomeWizardConfig}
+						baseContext={baseContext}
+					/>
+				</div>
+			</div>
+		</>
+	);
+}
+
+// Convert the React component to a web component
+const InstallESPHomeFirmwareWebComponent = r2wc(
+	InstallESPHomeFirmwareWizard,
+	React,
+	ReactDOM,
+);
+
+// Register the web component
+customElements.define(
+	"install-esphome-firmware",
+	InstallESPHomeFirmwareWebComponent,
+);
+
+export default InstallESPHomeFirmwareWizard;

--- a/src/wizards/index.ts
+++ b/src/wizards/index.ts
@@ -1,15 +1,21 @@
-import { installFirmwareWizardConfig } from './install-firmware';
-import { updateESPFirmwareWizardConfig } from './update-esp-firmware';
+import { installFirmwareWizardConfig } from "./install-firmware";
+import {
+	updateESPFirmwareWizardConfig,
+	updateESPBridgeWizardConfig,
+	updateESPHomeWizardConfig,
+} from "./update-esp-firmware";
 // import { updateFirmwareWizardConfig } from './update-firmware';
 // import { eraseNVMWizardConfig } from './erase-nvm';
-import { recoverAdapterWizardConfig } from './recover-adapter';
+import { recoverAdapterWizardConfig } from "./recover-adapter";
 
 export const wizards = [
-  installFirmwareWizardConfig,
-  updateESPFirmwareWizardConfig,
-//   updateFirmwareWizardConfig,
-  recoverAdapterWizardConfig,
-//   eraseNVMWizardConfig,
+	installFirmwareWizardConfig,
+	updateESPFirmwareWizardConfig,
+	//   updateFirmwareWizardConfig,
+	recoverAdapterWizardConfig,
+	updateESPBridgeWizardConfig,
+	updateESPHomeWizardConfig,
+	//   eraseNVMWizardConfig,
 ] as const;
 
-export type WizardId = typeof wizards[number]['id'];
+export type WizardId = (typeof wizards)[number]["id"];

--- a/src/wizards/update-esp-firmware/InstallStep.tsx
+++ b/src/wizards/update-esp-firmware/InstallStep.tsx
@@ -110,20 +110,22 @@ export default function InstallStep({ context }: WizardStepProps<UpdateESPFirmwa
 		waitForPowerCycle();
 	}, [context, installState]);
 
+	// Auto-navigate on success or error (failsafe in case power-cycle effect doesn't trigger)
+	useEffect(() => {
+		if (installState.status === "success") {
+			if (context.state.selectedFirmware?.wifi) {
+				context.goToStep("Configure");
+			} else {
+				context.goToStep("Summary");
+			}
+		} else if (installState.status === "error") {
+			context.goToStep("Summary");
+		}
+	}, [context, installState.status]);
+
 	const handleESP32Connect = useCallback(async () => {
 		await context.requestESP32SerialPort();
 	}, [context]);
-
-	// Show completion state
-	if (installState.status === "success" || installState.status === "error") {
-		return (
-			<div className="text-center py-8">
-				<div className="text-gray-600 dark:text-gray-300">
-					<p>Installation process completed. Click "Next" to see the results.</p>
-				</div>
-			</div>
-		);
-	}
 
 	// Show downloading spinner
 	if (installState.status === "downloading") {

--- a/src/wizards/update-esp-firmware/index.ts
+++ b/src/wizards/update-esp-firmware/index.ts
@@ -1,2 +1,2 @@
-export { updateESPFirmwareWizardConfig, updateESPBridgeWizardConfig, updateESPHomeWizardConfig } from './wizard';
+export { updateESPFirmwareWizardConfig, installESPBridgeFirmwareWizardConfig as updateESPBridgeWizardConfig, installESPHomeFirmwareWizardConfig as updateESPHomeWizardConfig } from './wizard';
 export type { UpdateESPFirmwareState, ESPFirmwareOption, ConfigureState } from './wizard';

--- a/src/wizards/update-esp-firmware/index.ts
+++ b/src/wizards/update-esp-firmware/index.ts
@@ -1,2 +1,2 @@
-export { updateESPFirmwareWizardConfig } from './wizard';
+export { updateESPFirmwareWizardConfig, updateESPBridgeWizardConfig, updateESPHomeWizardConfig } from './wizard';
 export type { UpdateESPFirmwareState, ESPFirmwareOption, ConfigureState } from './wizard';

--- a/src/wizards/update-esp-firmware/wizard.ts
+++ b/src/wizards/update-esp-firmware/wizard.ts
@@ -458,11 +458,11 @@ export const updateESPFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState>
 };
 
 // Specialized wizard for updating ESP Bridge firmware only
-export const updateESPBridgeWizardConfig: WizardConfig<UpdateESPFirmwareState> = {
+export const installESPBridgeFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState> = {
 	id: "update-esp-bridge",
 	title: "Install USB Bridge firmware",
 	description:
-		"Update the USB Bridge firmware (default firmware) on your ZWA-2.",
+		"The default firmware that comes pre-installed on the ZWA-2.",
 	icon: CpuChipIcon,
 	iconForeground: "text-purple-700 dark:text-purple-400",
 	iconBackground: "bg-purple-50 dark:bg-purple-500/10",
@@ -503,11 +503,11 @@ export const updateESPBridgeWizardConfig: WizardConfig<UpdateESPFirmwareState> =
 };
 
 // Specialized wizard for updating ESPHome (Portable Z-Wave) firmware only
-export const updateESPHomeWizardConfig: WizardConfig<UpdateESPFirmwareState> = {
-	id: "update-esphome",
+export const installESPHomeFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState> = {
+	id: "install-esphome",
 	title: "Install Portable Z-Wave firmware",
 	description:
-		"Update the Portable Z-Wave (ESPHome) firmware on your ZWA-2 to enable WiFi connectivity.",
+		"Allows connecting to ZWA-2 via WiFi.",
 	icon: CpuChipIcon,
 	iconForeground: "text-purple-700 dark:text-purple-400",
 	iconBackground: "bg-purple-50 dark:bg-purple-500/10",

--- a/src/wizards/update-esp-firmware/wizard.ts
+++ b/src/wizards/update-esp-firmware/wizard.ts
@@ -466,6 +466,7 @@ export const updateESPBridgeWizardConfig: WizardConfig<UpdateESPFirmwareState> =
 	icon: CpuChipIcon,
 	iconForeground: "text-purple-700 dark:text-purple-400",
 	iconBackground: "bg-purple-50 dark:bg-purple-500/10",
+	standalone: true,
 	createInitialState: () => {
 		const manifestId = "usb_bridge";
 		const manifest = ESP_FIRMWARE_MANIFESTS[manifestId];
@@ -510,6 +511,7 @@ export const updateESPHomeWizardConfig: WizardConfig<UpdateESPFirmwareState> = {
 	icon: CpuChipIcon,
 	iconForeground: "text-purple-700 dark:text-purple-400",
 	iconBackground: "bg-purple-50 dark:bg-purple-500/10",
+	standalone: true,
 	createInitialState: () => {
 		const manifest = ESP_FIRMWARE_MANIFESTS.esphome;
 		return {

--- a/src/wizards/update-esp-firmware/wizard.ts
+++ b/src/wizards/update-esp-firmware/wizard.ts
@@ -22,7 +22,7 @@ export const COMBINED_DEVICE_FILTERS = [
  * Available ESP firmware manifests
  */
 export const ESP_FIRMWARE_MANIFESTS: Record<string, ESPFirmwareManifest> = {
-	usb: {
+	usb_bridge: {
 		label: "USB Bridge",
 		description: "The default firmware that comes pre-installed on the ZWA-2.",
 		manifestUrl: "https://firmware.esphome.io/ha-connect-zwa-2/zwave-esp-bridge/manifest.json",
@@ -274,6 +274,143 @@ async function handleInstallStepEntry(context: WizardContext<UpdateESPFirmwareSt
 	}
 }
 
+async function handleConnectStepBeforeNavigate(context: WizardContext<UpdateESPFirmwareState>): Promise<boolean> {
+	// Handle device detection for ESP firmware update
+	const connectionState = context.connectionState;
+	if (connectionState.status === 'connected') {
+		// Determine device type based on connection type
+		let deviceType: 'zwa2' | 'esp32' | 'unknown' = 'unknown';
+
+		if (connectionState.type === 'zwa2') {
+			deviceType = 'zwa2';
+		} else if (connectionState.type === 'esp32') {
+			deviceType = 'esp32';
+		}
+
+		// Update wizard state with device detection results
+		context.setState(prev => ({
+			...prev,
+			deviceType,
+		}));
+	}
+
+	return await context.afterConnect();
+}
+
+function blockNavigationDuringInstall(context: WizardContext<UpdateESPFirmwareState>): boolean {
+	const { installState } = context.state;
+	// Block navigation during critical operations: downloading, entering bootloader, or installing
+	return installState.status === "downloading" ||
+		installState.status === "entering-bootloader" ||
+		installState.status === "installing";
+}
+
+async function handleConfigureStepEntry(context: WizardContext<UpdateESPFirmwareState>): Promise<void> {
+	// Check if WiFi configuration is supported by the selected firmware
+	const { selectedFirmware, installState, configureState } = context.state;
+
+	// Only allow configuration if installation was successful
+	if (installState.status !== "success") {
+		context.setState((prev) => ({
+			...prev,
+			configureState: { status: "skipped" },
+		}));
+		context.goToStep("Summary");
+		return;
+	}
+
+	// Check if the selected firmware supports WiFi configuration
+	if (!selectedFirmware?.wifi) {
+		// Skip this step if firmware doesn't support WiFi
+		context.setState((prev) => ({
+			...prev,
+			configureState: { status: "skipped" },
+		}));
+		context.goToStep("Summary");
+		return;
+	}
+
+	// If we're already in ready or error state (user came back to retry), don't wait again
+	if (configureState.status === "ready" || configureState.status === "error") {
+		return;
+	}
+
+	// Set waiting-for-startup state
+	context.setState((prev) => ({
+		...prev,
+		configureState: { status: "waiting-for-startup" },
+	}));
+
+	// Wait 10 seconds to give the firmware time to start and scan WiFi networks
+	const { wait } = await import("alcalzone-shared/async");
+	await wait(10000);
+
+	// Transition to ready state
+	context.setState((prev) => ({
+		...prev,
+		configureState: { status: "ready" },
+	}));
+
+	// Note: We no longer disconnect here - improv-wifi will manage its own connection
+}
+
+async function handleConfigureStepSkip(context: WizardContext<UpdateESPFirmwareState>): Promise<boolean> {
+	// Mark as skipped when user clicks Skip
+	context.setState((prev) => ({
+		...prev,
+		configureState: { status: "skipped" },
+	}));
+	return true;
+}
+
+async function handleSummaryStepFinish(context: WizardContext<UpdateESPFirmwareState>): Promise<boolean> {
+	// Disconnect the ESP32 serial port when finishing the wizard
+	if (context.onDisconnect) {
+		await context.onDisconnect();
+	}
+	return true;
+}
+
+// Navigation button configurations
+const connectStepButtons = {
+	next: {
+		label: "Next",
+		disabled: (context: WizardContext<UpdateESPFirmwareState>) => context.connectionState.status !== 'connected',
+		beforeNavigate: handleConnectStepBeforeNavigate,
+	},
+	cancel: {
+		label: "Cancel",
+	},
+};
+
+const fileSelectStepButtons = {
+	next: {
+		label: "Install",
+		disabled: (context: WizardContext<UpdateESPFirmwareState>) => !context.state.selectedFirmware,
+	},
+	back: {
+		label: "Back",
+	},
+	cancel: {
+		label: "Cancel",
+	},
+};
+
+const configureStepButtons = {
+	next: {
+		label: "Skip",
+		beforeNavigate: handleConfigureStepSkip,
+		disabled: (context: WizardContext<UpdateESPFirmwareState>) => context.state.configureState.status === 'waiting-for-startup'
+	},
+};
+
+const summaryStepButtons = {
+	next: {
+		label: "Finish",
+		beforeNavigate: handleSummaryStepFinish,
+	},
+};
+
 export const updateESPFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState> = {
 	id: "update-esp",
 	title: "Update ESP firmware",
@@ -292,148 +429,124 @@ export const updateESPFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState>
 		{
 			name: "Connect",
 			component: ESPConnectStep,
-			navigationButtons: {
-				next: {
-					label: "Next",
-					disabled: (context) => context.connectionState.status !== 'connected',
-					beforeNavigate: async (context) => {
-						// Handle device detection for ESP firmware update
-						const connectionState = context.connectionState;
-						if (connectionState.status === 'connected') {
-							// Determine device type based on connection type
-							let deviceType: 'zwa2' | 'esp32' | 'unknown' = 'unknown';
-
-							if (connectionState.type === 'zwa2') {
-								deviceType = 'zwa2';
-							} else if (connectionState.type === 'esp32') {
-								deviceType = 'esp32';
-							}
-
-							// Update wizard state with device detection results
-							context.setState(prev => ({
-								...prev,
-								deviceType,
-							}));
-						}
-
-						return await context.afterConnect();
-					},
-				},
-				cancel: {
-					label: "Cancel",
-				},
-			},
+			navigationButtons: connectStepButtons,
 		},
 		{
 			name: "Select firmware",
 			component: FileSelectStep,
-			navigationButtons: {
-				next: {
-					label: "Install",
-					disabled: (context) => !context.state.selectedFirmware,
-				},
-				back: {
-					label: "Back",
-				},
-				cancel: {
-					label: "Cancel",
-				},
-			},
+			navigationButtons: fileSelectStepButtons,
 		},
 		{
 			name: "Install firmware",
 			component: InstallStep,
 			onEnter: handleInstallStepEntry,
-			blockBrowserNavigation: (context) => {
-				const { installState } = context.state;
-				// Block navigation during critical operations: downloading, entering bootloader, or installing
-				return installState.status === "downloading" ||
-					installState.status === "entering-bootloader" ||
-					installState.status === "installing";
-			},
+			blockBrowserNavigation: blockNavigationDuringInstall,
 		},
 		{
 			name: "Configure",
 			component: ConfigureStep,
-			onEnter: async (context) => {
-				// Check if WiFi configuration is supported by the selected firmware
-				const { selectedFirmware, installState, configureState } = context.state;
-
-				// Only allow configuration if installation was successful
-				if (installState.status !== "success") {
-					context.setState((prev) => ({
-						...prev,
-						configureState: { status: "skipped" },
-					}));
-					context.goToStep("Summary");
-					return;
-				}
-
-				// Check if the selected firmware supports WiFi configuration
-				if (!selectedFirmware?.wifi) {
-					// Skip this step if firmware doesn't support WiFi
-					context.setState((prev) => ({
-						...prev,
-						configureState: { status: "skipped" },
-					}));
-					context.goToStep("Summary");
-					return;
-				}
-
-				// If we're already in ready or error state (user came back to retry), don't wait again
-				if (configureState.status === "ready" || configureState.status === "error") {
-					return;
-				}
-
-				// Set waiting-for-startup state
-				context.setState((prev) => ({
-					...prev,
-					configureState: { status: "waiting-for-startup" },
-				}));
-
-				// Wait 10 seconds to give the firmware time to start and scan WiFi networks
-				const { wait } = await import("alcalzone-shared/async");
-				await wait(10000);
-
-				// Transition to ready state
-				context.setState((prev) => ({
-					...prev,
-					configureState: { status: "ready" },
-				}));
-
-				// Note: We no longer disconnect here - improv-wifi will manage its own connection
-			},
-			navigationButtons: {
-				next: {
-					label: "Skip",
-					beforeNavigate: async (context) => {
-						// Mark as skipped when user clicks Skip
-						context.setState((prev) => ({
-							...prev,
-							configureState: { status: "skipped" },
-						}));
-						return true;
-					},
-					disabled: (context) => context.state.configureState.status === 'waiting-for-startup'
-				},
-			},
+			onEnter: handleConfigureStepEntry,
+			navigationButtons: configureStepButtons,
 		},
 		{
 			name: "Summary",
 			component: SummaryStep,
 			isFinal: true,
-			navigationButtons: {
-				next: {
-					label: "Finish",
-					beforeNavigate: async (context) => {
-						// Disconnect the ESP32 serial port when finishing the wizard
-						if (context.onDisconnect) {
-							await context.onDisconnect();
-						}
-						return true;
-					},
-				},
+			navigationButtons: summaryStepButtons,
+		},
+	],
+};
+
+// Specialized wizard for updating ESP Bridge firmware only
+export const updateESPBridgeWizardConfig: WizardConfig<UpdateESPFirmwareState> = {
+	id: "update-esp-bridge",
+	title: "Install USB Bridge firmware",
+	description:
+		"Update the USB Bridge firmware (default firmware) on your ZWA-2.",
+	icon: CpuChipIcon,
+	iconForeground: "text-purple-700 dark:text-purple-400",
+	iconBackground: "bg-purple-50 dark:bg-purple-500/10",
+	createInitialState: () => {
+		const manifestId = "usb_bridge";
+		const manifest = ESP_FIRMWARE_MANIFESTS[manifestId];
+		return {
+			selectedFirmware: {
+				type: "manifest",
+				manifestId,
+				label: manifest.label,
 			},
+			installState: { status: "idle" },
+			configureState: { status: "idle" },
+			deviceType: null,
+		};
+	},
+	steps: [
+		{
+			name: "Connect",
+			component: ESPConnectStep,
+			navigationButtons: connectStepButtons,
+		},
+		{
+			name: "Install firmware",
+			component: InstallStep,
+			onEnter: handleInstallStepEntry,
+			blockBrowserNavigation: blockNavigationDuringInstall,
+		},
+		{
+			name: "Summary",
+			component: SummaryStep,
+			isFinal: true,
+			navigationButtons: summaryStepButtons,
+		},
+	],
+};
+
+// Specialized wizard for updating ESPHome (Portable Z-Wave) firmware only
+export const updateESPHomeWizardConfig: WizardConfig<UpdateESPFirmwareState> = {
+	id: "update-esphome",
+	title: "Install Portable Z-Wave firmware",
+	description:
+		"Update the Portable Z-Wave (ESPHome) firmware on your ZWA-2 to enable WiFi connectivity.",
+	icon: CpuChipIcon,
+	iconForeground: "text-purple-700 dark:text-purple-400",
+	iconBackground: "bg-purple-50 dark:bg-purple-500/10",
+	createInitialState: () => {
+		const manifest = ESP_FIRMWARE_MANIFESTS.esphome;
+		return {
+			selectedFirmware: {
+				type: "manifest",
+				manifestId: "esphome",
+				label: manifest.label,
+				wifi: true,
+			},
+			installState: { status: "idle" },
+			configureState: { status: "idle" },
+			deviceType: null,
+		};
+	},
+	steps: [
+		{
+			name: "Connect",
+			component: ESPConnectStep,
+			navigationButtons: connectStepButtons,
+		},
+		{
+			name: "Install firmware",
+			component: InstallStep,
+			onEnter: handleInstallStepEntry,
+			blockBrowserNavigation: blockNavigationDuringInstall,
+		},
+		{
+			name: "Configure",
+			component: ConfigureStep,
+			onEnter: handleConfigureStepEntry,
+			navigationButtons: configureStepButtons,
+		},
+		{
+			name: "Summary",
+			component: SummaryStep,
+			isFinal: true,
+			navigationButtons: summaryStepButtons,
 		},
 	],
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,42 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { resolve } from "path";
 
 // https://vite.dev/config/
 export default defineConfig({
 	plugins: [react()],
 	base: "/zwa2-toolbox/",
 	css: {
-		postcss: './postcss.config.cjs',
+		postcss: "./postcss.config.cjs",
 	},
 	build: {
 		outDir: "dist",
 		sourcemap: true,
+		rollupOptions: {
+			input: {
+				main: resolve(__dirname, "index.html"),
+				"install-esp-bridge-firmware": resolve(
+					__dirname,
+					"src/standalone/install-esp-bridge-firmware.tsx",
+				),
+				"install-esphome-firmware": resolve(
+					__dirname,
+					"src/standalone/install-esphome-firmware.tsx",
+				),
+			},
+			output: {
+				entryFileNames: (chunkInfo) => {
+					// Keep the standalone web components as separate JS files
+					if (
+						chunkInfo.name === "install-esp-bridge-firmware" ||
+						chunkInfo.name === "install-esphome-firmware"
+					) {
+						return "standalone/[name].js";
+					}
+					return "assets/[name]-[hash].js";
+				},
+			},
+		},
 	},
 	server: {
 		port: 5173,


### PR DESCRIPTION
This PR adds two JS entry points that each expose a web component to install the ESPHome and the default ESP bridge firmware.