### PR TITLE
Support overriding the manifest URL and label in `install-esp-bridge-firmware` component

### DIFF
--- a/public/test-install-esp-bridge.html
+++ b/public/test-install-esp-bridge.html
@@ -6,8 +6,20 @@
 		<title>Install ESP Bridge Firmware</title>
 	</head>
 	<body>
+		<h1>Default USB Bridge Firmware</h1>
+		<p>This example uses the default USB Bridge firmware:</p>
 		<!-- The web component will be rendered here -->
 		<install-esp-bridge-firmware></install-esp-bridge-firmware>
+
+		<hr style="margin: 3rem 0;" />
+
+		<h1>Custom Firmware with Manifest Property</h1>
+		<p>This example uses the ESPHome manifest with custom properties:</p>
+		<!-- Example with custom manifest and label -->
+		<install-esp-bridge-firmware
+			manifest="https://firmware.esphome.io/ha-connect-zwa-2/home-assistant-zwa-2/manifest.json"
+			label="Custom ESPHome Firmware">
+		</install-esp-bridge-firmware>
 
 		<!-- Load the web component script -->
 		<script type="module" src="./standalone/install-esp-bridge-firmware.js"></script>

--- a/src/standalone/install-esp-bridge-firmware.tsx
+++ b/src/standalone/install-esp-bridge-firmware.tsx
@@ -5,15 +5,71 @@ import Wizard from "../components/Wizard";
 import { updateESPBridgeWizardConfig } from "../wizards/update-esp-firmware";
 import { useBaseWizardContext } from "../hooks/useBaseWizardContext";
 import styles from "../index.css?inline";
+import type { WizardConfig } from "../components/Wizard";
+import type { UpdateESPFirmwareState } from "../wizards/update-esp-firmware";
 
-function InstallESPBridgeFirmwareWizard() {
+export interface InstallESPBridgeFirmwareProps {
+	/**
+	 * Custom manifest URL to override the default firmware manifest.
+	 * If provided, the wizard will install firmware from this manifest instead of the default USB Bridge firmware.
+	 */
+	manifest?: string;
+
+	/**
+	 * Custom label for the firmware being installed.
+	 * This will be displayed in the wizard UI to identify the firmware.
+	 */
+	label?: string;
+}
+
+/**
+ * Creates a customized wizard config with overridden manifest and/or label.
+ * If no customization is needed, returns the default config.
+ */
+function createWizardConfig(
+	manifest?: string,
+	label?: string,
+): WizardConfig<UpdateESPFirmwareState> {
+	if (!manifest && !label) {
+		// Use default config if no customization
+		return updateESPBridgeWizardConfig;
+	}
+
+	// Create a customized config with overridden manifest and/or label
+	const customConfig: WizardConfig<UpdateESPFirmwareState> = {
+		...updateESPBridgeWizardConfig,
+		createInitialState: () => {
+			const defaultState = updateESPBridgeWizardConfig.createInitialState();
+
+			if (manifest || label) {
+				return {
+					...defaultState,
+					selectedFirmware: {
+						type: "manifest",
+						manifestId: "custom", // Use a custom ID for override manifests
+						label: label || defaultState.selectedFirmware?.label || "Custom firmware",
+						// Store the custom manifest URL in a way that can be accessed during installation
+						...(manifest && { manifestUrl: manifest }),
+					},
+				};
+			}
+
+			return defaultState;
+		},
+	};
+
+	return customConfig;
+}
+
+function InstallESPBridgeFirmwareWizard({ manifest, label }: InstallESPBridgeFirmwareProps) {
 	const baseContext = useBaseWizardContext();
+	const wizardConfig = createWizardConfig(manifest, label);
 
 	return (
 		<>
 			<style>{styles}</style>
 			<Wizard
-				config={updateESPBridgeWizardConfig}
+				config={wizardConfig}
 				baseContext={baseContext}
 			/>
 		</>
@@ -25,6 +81,12 @@ const InstallESPBridgeFirmwareWebComponent = r2wc(
 	InstallESPBridgeFirmwareWizard,
 	React,
 	ReactDOM,
+	{
+		props: {
+			manifest: "string",
+			label: "string",
+		},
+	},
 );
 
 // Register the web component


### PR DESCRIPTION
This PR adds two optional props `manifest` and `label` to the `install-esp-bridge-firmware` component that allow installing a different firmware than the default bridge firmware by passing the URL to a different ESPHome manifest.