### PR TITLE
Allow customizing strings in bridge firmware installer

### DIFF
--- a/public/test-install-esp-bridge.html
+++ b/public/test-install-esp-bridge.html
@@ -18,7 +18,10 @@
 		<!-- Example with custom manifest and label -->
 		<install-esp-bridge-firmware
 			manifest="https://firmware.esphome.io/ha-connect-zwa-2/home-assistant-zwa-2/manifest.json"
-			label="Custom ESPHome Firmware">
+			label="Custom ESPHome Firmware"
+			device_name="Waveshare PoE"
+			serialport_label="W4v3"
+		>
 		</install-esp-bridge-firmware>
 
 		<!-- Load the web component script -->

--- a/src/wizards/erase-nvm/wizard.ts
+++ b/src/wizards/erase-nvm/wizard.ts
@@ -3,7 +3,7 @@ import ConnectStep from "../../components/steps/ConnectStep";
 import ConfirmStep from "./ConfirmStep";
 import EraseStep from "./EraseStep";
 import SummaryStep from "./SummaryStep";
-import type { WizardConfig, WizardContext } from "../../components/Wizard";
+import type { WizardConfig, WizardContext, WizardStepProps } from "../../components/Wizard";
 import { DriverMode } from "zwave-js";
 
 export interface EraseNVMState {
@@ -13,6 +13,8 @@ export interface EraseNVMState {
 	eraseResult: "success" | "warning" | "error" | null;
 	errorMessage: string;
 }
+
+export type EraseNVMWizardStepProps = WizardStepProps<EraseNVMState>;
 
 // FIXME: We should distinguish between erasing the NVM and simply factory resetting a Z-Wave controller (hard reset)
 

--- a/src/wizards/install-firmware/wizard.ts
+++ b/src/wizards/install-firmware/wizard.ts
@@ -3,7 +3,7 @@ import ConnectStep from "../../components/steps/ConnectStep";
 import FileSelectStep from "./FileSelectStep";
 import FlashStep from "./FlashStep";
 import SummaryStep from "./SummaryStep.tsx";
-import type { WizardConfig, WizardContext } from "../../components/Wizard";
+import type { WizardConfig, WizardContext, WizardStepProps } from "../../components/Wizard";
 import { downloadLatestFirmware } from "../../lib/firmware-download";
 import { DriverMode } from "zwave-js";
 
@@ -20,6 +20,8 @@ export interface InstallFirmwareState {
 	currentSubStep: number;
 	isDownloading: boolean;
 }
+
+export type InstallFirmwareWizardStepProps = WizardStepProps<InstallFirmwareState>;
 
 async function handleInstallStepEntry(context: WizardContext<InstallFirmwareState>): Promise<void> {
 	const { flashResult, isFlashing, selectedFirmware } = context.state;

--- a/src/wizards/recover-adapter/wizard.ts
+++ b/src/wizards/recover-adapter/wizard.ts
@@ -3,7 +3,7 @@ import ConnectStep from "../../components/steps/ConnectStep";
 import DiagnoseStep from "./DiagnoseStep.tsx";
 import RecoveryStep from "./RecoveryStep.tsx";
 import SummaryStep from "./SummaryStep.tsx";
-import type { WizardConfig, WizardContext } from "../../components/Wizard";
+import type { WizardConfig, WizardContext, WizardStepProps } from "../../components/Wizard";
 import { DriverMode } from "zwave-js";
 import type { ReactNode } from "react";
 import { downloadLatestFirmware, openFirmwareFile } from "../../lib/firmware-download";
@@ -38,6 +38,8 @@ export interface RecoverAdapterState {
 	recoveryError: string | null;
 	downloadedFirmwareName: string | null;
 }
+
+export type RecoverAdapterWizardStepProps = WizardStepProps<RecoverAdapterState>;
 
 async function handleRecoveryNavigation(
 	context: WizardContext<RecoverAdapterState>,

--- a/src/wizards/update-esp-firmware/ConfigureStep.tsx
+++ b/src/wizards/update-esp-firmware/ConfigureStep.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { WifiIcon } from '@heroicons/react/24/outline';
-import type { WizardStepProps } from '../../components/Wizard';
-import type { UpdateESPFirmwareState } from './wizard';
+import type { UpdateESPFirmwareWizardStepProps } from './wizard';
 import 'improv-wifi-serial-sdk/dist/web/serial-launch-button';
 import Alert from '../../components/Alert';
 import Spinner from '../../components/Spinner';
@@ -28,7 +27,7 @@ interface ImprovClosedEvent extends CustomEvent {
 	};
 }
 
-export default function ConfigureStep({ context }: WizardStepProps<UpdateESPFirmwareState>) {
+export default function ConfigureStep({ context }: UpdateESPFirmwareWizardStepProps) {
 	const improvButtonRef = useRef<HTMLElement | null>(null);
 	const navigatedToSummaryRef = useRef<boolean>(false);
 
@@ -123,7 +122,7 @@ export default function ConfigureStep({ context }: WizardStepProps<UpdateESPFirm
 					Configure WiFi
 				</h3>
 				<p className="text-gray-600 dark:text-gray-300">
-					Set up WiFi credentials for your ZWA-2
+					Set up WiFi credentials for your {context.labels.deviceName}
 				</p>
 			</div>
 
@@ -138,7 +137,7 @@ export default function ConfigureStep({ context }: WizardStepProps<UpdateESPFirm
 
 			<Alert title="Note">
 				<p>
-					You can skip this step, but you won't be able to use the ZWA-2 until it's connected to WiFi.
+					You can skip this step, but you won't be able to use the {context.labels.deviceName} until it's connected to WiFi.
 				</p>
 			</Alert>
 

--- a/src/wizards/update-esp-firmware/ESPConnectStep.tsx
+++ b/src/wizards/update-esp-firmware/ESPConnectStep.tsx
@@ -1,12 +1,11 @@
 import { LinkIcon } from '@heroicons/react/24/outline';
 import { useEffect, useRef } from 'react';
-import type { WizardStepProps } from '../../components/Wizard';
-import type { UpdateESPFirmwareState } from './wizard';
+import type { UpdateESPFirmwareWizardStepProps } from './wizard';
 
 /**
  * Connect step for ESP firmware wizard that follows the standard ConnectStep pattern
  */
-export default function ESPConnectStep({ context }: WizardStepProps<UpdateESPFirmwareState>) {
+export default function ESPConnectStep({ context }: UpdateESPFirmwareWizardStepProps) {
   const isConnected = context.connectionState.status === 'connected';
   const serialPort = context.connectionState.status === 'connected' ? context.connectionState.port : null;
 
@@ -31,19 +30,23 @@ export default function ESPConnectStep({ context }: WizardStepProps<UpdateESPFir
     prevSerialPort.current = serialPort;
   }, [serialPort, context]);
 
+  const { deviceName, serialportLabel, espVariant } = context.labels;
+
+  // Build the connection description, conditionally including serialportLabel
+  const connectionDescription = isConnected
+    ? `Successfully connected to your ${deviceName}.`
+    : `First, we need to establish a connection to your ${deviceName}. Depending on the ESP firmware, the device will be called ${serialportLabel ? `"${serialportLabel}", ` : ""}"${espVariant}" or "USB JTAG/serial debug unit".`;
+
   return (
     <div className="text-center py-8">
       <div className={`mb-4 ${isConnected ? 'text-green-600 dark:text-green-400' : 'text-gray-400 dark:text-gray-600'}`}>
         <LinkIcon className="w-16 h-16 mx-auto" />
       </div>
       <h3 className="text-lg font-medium text-primary mb-2">
-        {isConnected ? 'ZWA-2 Connected' : 'Connect to ZWA-2'}
+        {isConnected ? `${deviceName} Connected` : `Connect to ${deviceName}`}
       </h3>
       <p className="text-gray-600 dark:text-gray-300 mb-6">
-        {isConnected
-          ? 'Successfully connected to your ZWA-2.'
-          : 'First, we need to establish a connection to your ZWA-2. Depending on the ESP firmware, the device will be called "ZWA-2", "ESP32-S3" or "USB JTAG/serial debug unit".'
-        }
+        {connectionDescription}
       </p>
       {!isConnected && (
         <button

--- a/src/wizards/update-esp-firmware/FileSelectStep.tsx
+++ b/src/wizards/update-esp-firmware/FileSelectStep.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import { InformationCircleIcon } from '@heroicons/react/24/outline';
-import type { WizardStepProps } from '../../components/Wizard';
-import type { UpdateESPFirmwareState, ESPFirmwareOption } from './wizard';
+import type { UpdateESPFirmwareWizardStepProps, ESPFirmwareOption } from './wizard';
 import { ESP_FIRMWARE_MANIFESTS } from './wizard';
 import { fetchManifestFirmwareInfo } from '../../lib/esp-firmware-download';
 import Modal from '../../components/Modal';
 
-export default function FileSelectStep({ context }: WizardStepProps<UpdateESPFirmwareState>) {
+export default function FileSelectStep({ context }: UpdateESPFirmwareWizardStepProps) {
   const { selectedFirmware } = context.state;
   const [isChangelogModalOpen, setIsChangelogModalOpen] = useState(false);
   const [activeChangelogManifest, setActiveChangelogManifest] = useState<string | null>(null);
@@ -92,7 +91,7 @@ export default function FileSelectStep({ context }: WizardStepProps<UpdateESPFir
         Choose which firmware package to install
       </h3>
       <p className="text-gray-600 dark:text-gray-300 mb-6">
-        Select the firmware package you want to install on your ZWA-2.
+        Select the firmware package you want to install on your {context.labels.deviceName}.
       </p>
 
       <div className="space-y-4">

--- a/src/wizards/update-esp-firmware/InstallStep.tsx
+++ b/src/wizards/update-esp-firmware/InstallStep.tsx
@@ -1,13 +1,12 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { LinkIcon, LinkSlashIcon } from '@heroicons/react/24/outline';
-import type { WizardStepProps } from '../../components/Wizard';
-import type { UpdateESPFirmwareState } from './wizard';
+import type { UpdateESPFirmwareWizardStepProps } from './wizard';
 import { flashESPFirmwareWithData } from './wizard';
 import CircularProgress from '../../components/CircularProgress';
 import Alert from '../../components/Alert';
 import Spinner from '../../components/Spinner';
 
-export default function InstallStep({ context }: WizardStepProps<UpdateESPFirmwareState>) {
+export default function InstallStep({ context }: UpdateESPFirmwareWizardStepProps) {
 	const { installState } = context.state;
 
 	const prevSerialPort = useRef<SerialPort | null>(null);
@@ -182,7 +181,7 @@ export default function InstallStep({ context }: WizardStepProps<UpdateESPFirmwa
 						}
 					</p>
 					<p className="text-gray-600 dark:text-gray-300">
-						The device is usually called "ESP32-S3" or "USB JTAG/serial debug unit".
+						The device is usually called "{context.labels.espVariant}" or "USB JTAG/serial debug unit".
 					</p>
 				</div>
 
@@ -199,9 +198,9 @@ export default function InstallStep({ context }: WizardStepProps<UpdateESPFirmwa
 						{bootloaderEntryFailed && (
 							<Alert title="To trigger the bootloader manually">
 								<ol className="list-decimal pl-6 my-2 space-y-1">
-									<li>Unplug the ZWA-2 and open it up</li>
+									<li>Unplug the {context.labels.deviceName} and open it up</li>
 									<li>On the top right of the PCB, under "ESP GPIO pins", bridge GPIO0 and GND with something conductive</li>
-									<li>Plug the ZWA-2 back in</li>
+									<li>Plug the {context.labels.deviceName} back in</li>
 									<li>Retry connecting</li>
 								</ol>
 								<span className="block mt-2">Don't forget to remove the bridge after flashing!</span>
@@ -246,7 +245,7 @@ export default function InstallStep({ context }: WizardStepProps<UpdateESPFirmwa
 					Firmware installed successfully
 				</h3>
 				<p className="text-gray-600 dark:text-gray-300">
-					Please power cycle your ZWA-2 to activate the new firmware.
+					Please power cycle your {context.labels.deviceName} to activate the new firmware.
 				</p>
 		</div>
 		);

--- a/src/wizards/update-esp-firmware/SummaryStep.tsx
+++ b/src/wizards/update-esp-firmware/SummaryStep.tsx
@@ -1,7 +1,6 @@
-import type { WizardStepProps } from '../../components/Wizard';
-import type { UpdateESPFirmwareState } from './wizard';
+import type { UpdateESPFirmwareWizardStepProps } from './wizard';
 
-export default function SummaryStep({ context }: WizardStepProps<UpdateESPFirmwareState>) {
+export default function SummaryStep({ context }: UpdateESPFirmwareWizardStepProps) {
   const { installState, configureState } = context.state;
 
   const getResultContent = () => {

--- a/src/wizards/update-esp-firmware/index.ts
+++ b/src/wizards/update-esp-firmware/index.ts
@@ -1,2 +1,2 @@
 export { updateESPFirmwareWizardConfig, installESPBridgeFirmwareWizardConfig as updateESPBridgeWizardConfig, installESPHomeFirmwareWizardConfig as updateESPHomeWizardConfig } from './wizard';
-export type { UpdateESPFirmwareState, ESPFirmwareOption, ConfigureState } from './wizard';
+export type { UpdateESPFirmwareState, UpdateESPFirmwareLabels, UpdateESPFirmwareWizardStepProps, ESPFirmwareOption, ConfigureState } from './wizard';

--- a/src/wizards/update-esp-firmware/wizard.ts
+++ b/src/wizards/update-esp-firmware/wizard.ts
@@ -4,7 +4,7 @@ import InstallStep from "./InstallStep";
 import ConfigureStep from "./ConfigureStep";
 import SummaryStep from "./SummaryStep";
 import ESPConnectStep from "./ESPConnectStep";
-import type { WizardConfig, WizardContext } from "../../components/Wizard";
+import type { WizardConfig, WizardContext, WizardStepProps } from "../../components/Wizard";
 import { enterESPBootloader, ESP32_DEVICE_FILTERS } from "../../lib/esp-utils";
 import { ESPLoader, Transport, type FlashOptions, type LoaderOptions } from "esptool-js";
 import { ZWA2_DEVICE_FILTERS } from "../../lib/zwave";
@@ -82,6 +82,23 @@ export interface UpdateESPFirmwareState {
 	configureState: ConfigureState;
 	deviceType: 'zwa2' | 'esp32' | 'unknown' | null; // Track detected device type
 }
+
+export interface UpdateESPFirmwareLabels {
+	// Configurable labels for different hardware
+	/** How the device should be called standalone */
+	deviceName: string;
+	/**
+	 * How the device should be called when referring to the strings in the serial port selector.
+	 * Empty string ("") skips the text.
+	 */
+	serialportLabel: string;
+	/**
+	 * How the ESP chip variant should be called when referring to the serial port selector.
+	 */
+	espVariant: string;
+}
+
+export type UpdateESPFirmwareWizardStepProps = WizardStepProps<UpdateESPFirmwareState, UpdateESPFirmwareLabels>;
 
 export async function flashESPFirmwareWithData(
 	context: WizardContext<UpdateESPFirmwareState>,
@@ -423,7 +440,7 @@ const summaryStepButtons = {
 	},
 };
 
-export const updateESPFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState> = {
+export const updateESPFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState, UpdateESPFirmwareLabels> = {
 	id: "update-esp",
 	title: "Update ESP firmware",
 	description:
@@ -437,6 +454,11 @@ export const updateESPFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState>
 		configureState: { status: "idle" },
 		deviceType: null,
 	}),
+	labels: {
+		deviceName: "ZWA-2",
+		serialportLabel: "ZWA-2",
+		espVariant: "ESP32-S3",
+	},
 	steps: [
 		{
 			name: "Connect",
@@ -470,7 +492,7 @@ export const updateESPFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState>
 };
 
 // Specialized wizard for updating ESP Bridge firmware only
-export const installESPBridgeFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState> = {
+export const installESPBridgeFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState, UpdateESPFirmwareLabels> = {
 	id: "update-esp-bridge",
 	title: "Install USB Bridge firmware",
 	description:
@@ -492,6 +514,11 @@ export const installESPBridgeFirmwareWizardConfig: WizardConfig<UpdateESPFirmwar
 			configureState: { status: "idle" },
 			deviceType: null,
 		};
+	},
+	labels: {
+		deviceName: "ZWA-2",
+		serialportLabel: "ZWA-2",
+		espVariant: "ESP32-S3",
 	},
 	steps: [
 		{
@@ -515,7 +542,7 @@ export const installESPBridgeFirmwareWizardConfig: WizardConfig<UpdateESPFirmwar
 };
 
 // Specialized wizard for updating ESPHome (Portable Z-Wave) firmware only
-export const installESPHomeFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState> = {
+export const installESPHomeFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareState, UpdateESPFirmwareLabels> = {
 	id: "install-esphome",
 	title: "Install Portable Z-Wave firmware",
 	description:
@@ -537,6 +564,12 @@ export const installESPHomeFirmwareWizardConfig: WizardConfig<UpdateESPFirmwareS
 			configureState: { status: "idle" },
 			deviceType: null,
 		};
+	},
+	// ESPHome wizard always uses default ZWA-2 labels
+	labels: {
+		deviceName: "ZWA-2",
+		serialportLabel: "ZWA-2",
+		espVariant: "ESP32-S3",
 	},
 	steps: [
 		{

--- a/src/wizards/update-firmware/wizard.ts
+++ b/src/wizards/update-firmware/wizard.ts
@@ -2,7 +2,7 @@ import { CloudArrowUpIcon } from "@heroicons/react/24/outline";
 import ConnectStep from "../../components/steps/ConnectStep";
 import FileSelectStep from "./FileSelectStep";
 import FlashStep from "./FlashStep";
-import type { WizardConfig, WizardContext } from "../../components/Wizard";
+import type { WizardConfig, WizardContext, WizardStepProps } from "../../components/Wizard";
 import { openFirmwareFile } from "../../lib/firmware-download";
 
 export interface UpdateFirmwareState {
@@ -11,6 +11,8 @@ export interface UpdateFirmwareState {
 	progress: number;
 	isComplete: boolean;
 }
+
+export type UpdateFirmwareWizardStepProps = WizardStepProps<UpdateFirmwareState>;
 
 async function handleUpdateNavigation(
 	context: WizardContext<UpdateFirmwareState>,


### PR DESCRIPTION
This PR adds three properties to the `install-esp-bridge-firmware` component, allowing the customization of different strings in the wizard UI:
- `device_name`, default "ZWA-2"
- `serialport_label`, default "ZWA-2". Can be set to "" to avoid mentioning the device's serialport label.
- `esp_variant`, default "ESP32-S3". This does not affect the firmware selection, only for display purposes.

<img width="1118" height="485" alt="image" src="https://github.com/user-attachments/assets/285311bd-8438-42d8-85dd-c8e1ab117dd0" />
