### PR TITLE
Add configuration wizard

### DIFF
--- a/src/components/SmartStartQRCode.tsx
+++ b/src/components/SmartStartQRCode.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import { generateRepeaterQRCode } from "../lib/qr-code";
+
+export default function SmartStartQRCode({ dsk }: { dsk: string }) {
+	const [svgMarkup, setSvgMarkup] = useState<string | null>(null);
+
+	useEffect(() => {
+		generateRepeaterQRCode(dsk)
+			.then(setSvgMarkup)
+			.catch((err) => {
+				console.error("Failed to generate QR code:", err);
+			});
+	}, [dsk]);
+
+	if (!svgMarkup) return null;
+
+	return (
+		<div className="mt-4 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg">
+			<p className="font-medium text-blue-800 dark:text-blue-300 mb-3">
+				Scan QR code to join via SmartStart:
+			</p>
+			<div className="flex flex-col items-center">
+				<div
+					className="w-64 bg-white rounded-lg overflow-hidden [&>svg]:w-full [&>svg]:h-auto [&>svg]:block"
+					dangerouslySetInnerHTML={{ __html: svgMarkup }}
+				/>
+				<p className="mt-3 font-mono text-sm text-blue-900 dark:text-blue-100 select-all break-all">
+					DSK:{" "}
+					<span className="font-bold underline">
+						{dsk.slice(0, 5)}
+					</span>
+					{dsk.slice(5)}
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/src/lib/regions.ts
+++ b/src/lib/regions.ts
@@ -1,0 +1,95 @@
+import {
+	RFRegion,
+	getLegalPowerlevelMesh,
+	getLegalPowerlevelLR,
+} from "@zwave-js/core/definitions";
+import type { FirmwareType } from "./firmware-download";
+import type { ZWaveBinding } from "./zwave";
+
+/** CLI region codes and display labels used by the repeater firmware. */
+export const RF_REGIONS = [
+	{ label: "Europe", value: "EU" },
+	{ label: "USA", value: "US" },
+	{ label: "Australia/New Zealand", value: "ANZ" },
+	{ label: "Hong Kong", value: "HK" },
+	{ label: "India", value: "IN" },
+	{ label: "Israel", value: "IL" },
+	{ label: "Russia", value: "RU" },
+	{ label: "China", value: "CN" },
+	{ label: "Japan", value: "JP" },
+	{ label: "Korea", value: "KR" },
+] as const;
+
+/** Maps CLI region codes to the RFRegion enum used by the Serial API. */
+export const CLI_REGION_TO_RF_REGION: Record<string, RFRegion> = {
+	EU: RFRegion.Europe,
+	US: RFRegion.USA,
+	ANZ: RFRegion["Australia/New Zealand"],
+	HK: RFRegion["Hong Kong"],
+	IN: RFRegion.India,
+	IL: RFRegion.Israel,
+	RU: RFRegion.Russia,
+	CN: RFRegion.China,
+	JP: RFRegion.Japan,
+	KR: RFRegion.Korea,
+};
+
+export const FIRMWARE_TYPE_LABELS: Record<FirmwareType, string> = {
+	controller: "Controller",
+	repeater: "Repeater",
+	zniffer: "Zniffer",
+};
+
+/**
+ * Sets the RF region on a repeater, waits for reboot, verifies the change,
+ * and applies legal power level limits for the region.
+ *
+ * Returns `true` on success, or a string error message on failure.
+ */
+export async function applyRepeaterRegion(
+	binding: ZWaveBinding,
+	regionCode: string,
+): Promise<true | string> {
+	const setSuccess = await binding.setRegion(regionCode);
+	if (!setSuccess) {
+		return "Failed to set RF region. Please try again.";
+	}
+
+	// Wait for ZWA-2 to reboot
+	const { wait } = await import("alcalzone-shared/async");
+	await wait(1000);
+
+	// Verify region
+	const confirmedRegion = await binding.getRegion();
+	if (confirmedRegion !== regionCode) {
+		return `Region verification failed. Expected "${regionCode}" but got "${confirmedRegion ?? "unknown"}".`;
+	}
+
+	// Configure power levels if legal limits are known for this region
+	const rfRegion = CLI_REGION_TO_RF_REGION[regionCode];
+	if (rfRegion != null) {
+		const meshLimit = getLegalPowerlevelMesh(rfRegion);
+		const lrLimit = getLegalPowerlevelLR(rfRegion);
+
+		if (meshLimit != null || lrLimit != null) {
+			const current = await binding.getPowerlevel();
+			if (current) {
+				// Z-Wave JS returns dBm, CLI uses deci-dBm
+				const newMeshMax =
+					meshLimit != null
+						? meshLimit * 10
+						: current.txPowerMax;
+				const newLRMax =
+					lrLimit != null ? lrLimit * 10 : current.txPowerMaxLR;
+
+				await binding.setPowerlevel(
+					newMeshMax,
+					current.txPowerAdjust,
+					newLRMax,
+				);
+			}
+		}
+	}
+
+	return true;
+}

--- a/src/lib/zwave.ts
+++ b/src/lib/zwave.ts
@@ -629,6 +629,16 @@ export class ZWaveBinding {
 		}
 	}
 
+	// --- Controller-specific methods (Serial API mode) ---
+
+	/** Returns the controller instance, or null if the driver is not in Serial API mode. */
+	get controller() {
+		if (!this.driver || this.driver.mode !== DriverMode.SerialAPI) {
+			return null;
+		}
+		return this.driver.controller;
+	}
+
 	async disconnect(): Promise<void> {
 		if (this.driver) {
 			this.driver.removeAllListeners();

--- a/src/wizards/configure/ConfigureStep.tsx
+++ b/src/wizards/configure/ConfigureStep.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState, useCallback } from "react";
 import type { WizardStepProps } from "../../components/Wizard";
 import type { ConfigureState } from "./wizard";
-import { applyRegionConfiguration } from "./wizard";
+import {
+	applyRepeaterRegionConfiguration,
+	applyControllerRegionConfiguration,
+	toggleLED,
+	toggleTiltIndicator,
+} from "./wizard";
 import Spinner from "../../components/Spinner";
 import Alert from "../../components/Alert";
 import { generateRepeaterQRCode } from "../../lib/qr-code";
@@ -67,7 +72,7 @@ function RepeaterConfiguration({
 		context.state;
 
 	const handleApply = useCallback(async () => {
-		await applyRegionConfiguration(context);
+		await applyRepeaterRegionConfiguration(context);
 	}, [context]);
 
 	return (
@@ -150,6 +155,197 @@ function RepeaterConfiguration({
 	);
 }
 
+function Toggle({
+	label,
+	description,
+	enabled,
+	toggling,
+	onToggle,
+}: {
+	label: string;
+	description: string;
+	enabled: boolean;
+	toggling: boolean;
+	onToggle: (enabled: boolean) => void;
+}) {
+	return (
+		<div className="flex items-center justify-between">
+			<div>
+				<p className="text-sm font-medium text-primary">{label}</p>
+				<p className="text-sm text-secondary">{description}</p>
+			</div>
+			{toggling ? (
+				<Spinner size="h-5 w-5" />
+			) : (
+				<button
+					type="button"
+					role="switch"
+					aria-checked={enabled}
+					onClick={() => onToggle(!enabled)}
+					className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${
+						enabled
+							? "bg-blue-600 dark:bg-blue-500"
+							: "bg-gray-200 dark:bg-gray-700"
+					}`}
+				>
+					<span
+						aria-hidden="true"
+						className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+							enabled ? "translate-x-5" : "translate-x-0"
+						}`}
+					/>
+				</button>
+			)}
+		</div>
+	);
+}
+
+function ControllerConfiguration({
+	context,
+}: WizardStepProps<ConfigureState>) {
+	const {
+		selectedRegion,
+		configureStatus,
+		configureError,
+		supportedRegions,
+		ledEnabled,
+		tiltIndicatorEnabled,
+		togglingLed,
+		togglingTilt,
+	} = context.state;
+
+	const handleApplyRegion = useCallback(async () => {
+		await applyControllerRegionConfiguration(context);
+	}, [context]);
+
+	const handleToggleLed = useCallback(
+		(enabled: boolean) => {
+			void toggleLED(context, enabled);
+		},
+		[context],
+	);
+
+	const handleToggleTilt = useCallback(
+		(enabled: boolean) => {
+			void toggleTiltIndicator(context, enabled);
+		},
+		[context],
+	);
+
+	return (
+		<div className="space-y-8">
+			{/* Region selector */}
+			<div>
+				<h3 className="text-lg font-medium text-primary mb-2">
+					RF Region
+				</h3>
+				<p className="text-gray-600 dark:text-gray-300 mb-4">
+					Select the RF region for your Z-Wave controller.
+				</p>
+
+				{configureError && (
+					<div className="mb-4">
+						<Alert title="Configuration failed" severity="error">
+							<p>{configureError}</p>
+						</Alert>
+					</div>
+				)}
+
+				{configureStatus === "configuring" ? (
+					<div className="flex items-center gap-3">
+						<Spinner size="h-5 w-5" />
+						<span className="text-secondary">
+							Configuring RF region...
+						</span>
+					</div>
+				) : (
+					<div className="flex items-center gap-3">
+						<div>
+							<label
+								htmlFor="rf-region-ctrl"
+								className="sr-only"
+							>
+								RF Region
+							</label>
+							<select
+								id="rf-region-ctrl"
+								value={selectedRegion != null ? String(selectedRegion) : ""}
+								onChange={(e) => {
+									const val = e.target.value;
+									context.setState((prev) => ({
+										...prev,
+										selectedRegion: val ? Number(val) : null,
+										configureStatus: "idle",
+										configureError: null,
+									}));
+								}}
+								style={{ width: "16rem" }}
+								className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 py-2 pl-3 pr-10 text-gray-900 dark:text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 sm:text-sm"
+							>
+								<option value="">Select a region...</option>
+								{supportedRegions.map((region) => (
+									<option
+										key={region.value}
+										value={String(region.value)}
+										disabled={region.disabled}
+									>
+										{region.label}
+									</option>
+								))}
+							</select>
+						</div>
+						<button
+							onClick={handleApplyRegion}
+							disabled={
+								selectedRegion == null ||
+								selectedRegion === context.state.currentRegion
+							}
+							className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-blue-500 dark:hover:bg-blue-400"
+						>
+							Apply
+						</button>
+					</div>
+				)}
+
+				{configureStatus === "success" && (
+					<p className="mt-3 text-sm text-green-600 dark:text-green-400">
+						RF region configured successfully.
+					</p>
+				)}
+			</div>
+
+			{/* LED and Tilt toggles */}
+			{(ledEnabled != null || tiltIndicatorEnabled != null) && (
+				<div>
+					<h3 className="text-lg font-medium text-primary mb-4">
+						Device Settings
+					</h3>
+					<div className="space-y-4">
+						{ledEnabled != null && (
+							<Toggle
+								label="LED"
+								description="Turn the status LED on or off."
+								enabled={ledEnabled}
+								toggling={togglingLed}
+								onToggle={handleToggleLed}
+							/>
+						)}
+						{tiltIndicatorEnabled != null && (
+							<Toggle
+								label="Tilt indicator"
+								description="Show LED feedback when the device is tilted."
+								enabled={tiltIndicatorEnabled}
+								toggling={togglingTilt}
+								onToggle={handleToggleTilt}
+							/>
+						)}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
 function UnconfigurableFirmware({
 	firmwareType,
 }: {
@@ -192,6 +388,14 @@ export default function ConfigureStep({
 		return (
 			<div className="py-8">
 				<RepeaterConfiguration context={context} />
+			</div>
+		);
+	}
+
+	if (detectedFirmwareType === "controller") {
+		return (
+			<div className="py-8">
+				<ControllerConfiguration context={context} />
 			</div>
 		);
 	}

--- a/src/wizards/configure/ConfigureStep.tsx
+++ b/src/wizards/configure/ConfigureStep.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState, useCallback } from "react";
 import type { WizardStepProps } from "../../components/Wizard";
 import type { ConfigureState } from "./wizard";
 import {
@@ -9,71 +8,14 @@ import {
 } from "./wizard";
 import Spinner from "../../components/Spinner";
 import Alert from "../../components/Alert";
-import { generateRepeaterQRCode } from "../../lib/qr-code";
-
-const RF_REGIONS = [
-	{ label: "Europe", value: "EU" },
-	{ label: "USA", value: "US" },
-	{ label: "Australia/New Zealand", value: "ANZ" },
-	{ label: "Hong Kong", value: "HK" },
-	{ label: "India", value: "IN" },
-	{ label: "Israel", value: "IL" },
-	{ label: "Russia", value: "RU" },
-	{ label: "China", value: "CN" },
-	{ label: "Japan", value: "JP" },
-	{ label: "Korea", value: "KR" },
-] as const;
-
-const FIRMWARE_TYPE_LABELS = {
-	controller: "Controller",
-	repeater: "Repeater",
-	zniffer: "Zniffer",
-} as const;
-
-function SmartStartQRCode({ dsk }: { dsk: string }) {
-	const [svgMarkup, setSvgMarkup] = useState<string | null>(null);
-
-	useEffect(() => {
-		generateRepeaterQRCode(dsk)
-			.then(setSvgMarkup)
-			.catch((err) => {
-				console.error("Failed to generate QR code:", err);
-			});
-	}, [dsk]);
-
-	if (!svgMarkup) return null;
-
-	return (
-		<div className="mt-6 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg">
-			<p className="font-medium text-blue-800 dark:text-blue-300 mb-3">
-				Scan QR code to join via SmartStart:
-			</p>
-			<div className="flex flex-col items-center">
-				<div
-					className="w-64 bg-white rounded-lg overflow-hidden [&>svg]:w-full [&>svg]:h-auto [&>svg]:block"
-					dangerouslySetInnerHTML={{ __html: svgMarkup }}
-				/>
-				<p className="mt-3 font-mono text-sm text-blue-900 dark:text-blue-100 select-all break-all">
-					DSK:{" "}
-					<span className="font-bold underline">
-						{dsk.slice(0, 5)}
-					</span>
-					{dsk.slice(5)}
-				</p>
-			</div>
-		</div>
-	);
-}
+import SmartStartQRCode from "../../components/SmartStartQRCode";
+import { RF_REGIONS, FIRMWARE_TYPE_LABELS } from "../../lib/regions";
 
 function RepeaterConfiguration({
 	context,
 }: WizardStepProps<ConfigureState>) {
 	const { selectedRegion, configureStatus, configureError, dsk } =
 		context.state;
-
-	const handleApply = useCallback(async () => {
-		await applyRepeaterRegionConfiguration(context);
-	}, [context]);
 
 	return (
 		<div>
@@ -135,7 +77,7 @@ function RepeaterConfiguration({
 						</select>
 					</div>
 					<button
-						onClick={handleApply}
+						onClick={() => applyRepeaterRegionConfiguration(context)}
 						disabled={!selectedRegion || selectedRegion === context.state.currentRegion}
 						className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-blue-500 dark:hover:bg-blue-400"
 					>
@@ -214,24 +156,6 @@ function ControllerConfiguration({
 		togglingTilt,
 	} = context.state;
 
-	const handleApplyRegion = useCallback(async () => {
-		await applyControllerRegionConfiguration(context);
-	}, [context]);
-
-	const handleToggleLed = useCallback(
-		(enabled: boolean) => {
-			void toggleLED(context, enabled);
-		},
-		[context],
-	);
-
-	const handleToggleTilt = useCallback(
-		(enabled: boolean) => {
-			void toggleTiltIndicator(context, enabled);
-		},
-		[context],
-	);
-
 	return (
 		<div className="space-y-8">
 			{/* Region selector */}
@@ -295,7 +219,7 @@ function ControllerConfiguration({
 							</select>
 						</div>
 						<button
-							onClick={handleApplyRegion}
+							onClick={() => applyControllerRegionConfiguration(context)}
 							disabled={
 								selectedRegion == null ||
 								selectedRegion === context.state.currentRegion
@@ -327,7 +251,7 @@ function ControllerConfiguration({
 								description="Turn the status LED on or off."
 								enabled={ledEnabled}
 								toggling={togglingLed}
-								onToggle={handleToggleLed}
+								onToggle={(enabled) => toggleLED(context, enabled)}
 							/>
 						)}
 						{tiltIndicatorEnabled != null && (
@@ -336,7 +260,7 @@ function ControllerConfiguration({
 								description="Show LED feedback when the device is tilted."
 								enabled={tiltIndicatorEnabled}
 								toggling={togglingTilt}
-								onToggle={handleToggleTilt}
+								onToggle={(enabled) => toggleTiltIndicator(context, enabled)}
 							/>
 						)}
 					</div>

--- a/src/wizards/configure/ConfigureStep.tsx
+++ b/src/wizards/configure/ConfigureStep.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useState, useCallback } from "react";
+import type { WizardStepProps } from "../../components/Wizard";
+import type { ConfigureState } from "./wizard";
+import { applyRegionConfiguration } from "./wizard";
+import Spinner from "../../components/Spinner";
+import Alert from "../../components/Alert";
+import { generateRepeaterQRCode } from "../../lib/qr-code";
+
+const RF_REGIONS = [
+	{ label: "Europe", value: "EU" },
+	{ label: "USA", value: "US" },
+	{ label: "Australia/New Zealand", value: "ANZ" },
+	{ label: "Hong Kong", value: "HK" },
+	{ label: "India", value: "IN" },
+	{ label: "Israel", value: "IL" },
+	{ label: "Russia", value: "RU" },
+	{ label: "China", value: "CN" },
+	{ label: "Japan", value: "JP" },
+	{ label: "Korea", value: "KR" },
+] as const;
+
+const FIRMWARE_TYPE_LABELS = {
+	controller: "Controller",
+	repeater: "Repeater",
+	zniffer: "Zniffer",
+} as const;
+
+function SmartStartQRCode({ dsk }: { dsk: string }) {
+	const [svgMarkup, setSvgMarkup] = useState<string | null>(null);
+
+	useEffect(() => {
+		generateRepeaterQRCode(dsk)
+			.then(setSvgMarkup)
+			.catch((err) => {
+				console.error("Failed to generate QR code:", err);
+			});
+	}, [dsk]);
+
+	if (!svgMarkup) return null;
+
+	return (
+		<div className="mt-6 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg">
+			<p className="font-medium text-blue-800 dark:text-blue-300 mb-3">
+				Scan QR code to join via SmartStart:
+			</p>
+			<div className="flex flex-col items-center">
+				<div
+					className="w-64 bg-white rounded-lg overflow-hidden [&>svg]:w-full [&>svg]:h-auto [&>svg]:block"
+					dangerouslySetInnerHTML={{ __html: svgMarkup }}
+				/>
+				<p className="mt-3 font-mono text-sm text-blue-900 dark:text-blue-100 select-all break-all">
+					DSK:{" "}
+					<span className="font-bold underline">
+						{dsk.slice(0, 5)}
+					</span>
+					{dsk.slice(5)}
+				</p>
+			</div>
+		</div>
+	);
+}
+
+function RepeaterConfiguration({
+	context,
+}: WizardStepProps<ConfigureState>) {
+	const { selectedRegion, configureStatus, configureError, dsk } =
+		context.state;
+
+	const handleApply = useCallback(async () => {
+		await applyRegionConfiguration(context);
+	}, [context]);
+
+	return (
+		<div>
+			<h3 className="text-lg font-medium text-primary mb-2">
+				Configure RF Region
+			</h3>
+			<p className="text-gray-600 dark:text-gray-300 mb-6">
+				Select the RF region for your Z-Wave repeater. This must match
+				the region of the Z-Wave network you want to join.
+			</p>
+
+			{configureError && (
+				<div className="mb-6">
+					<Alert title="Configuration failed" severity="error">
+						<p>{configureError}</p>
+					</Alert>
+				</div>
+			)}
+
+			{configureStatus === "configuring" ? (
+				<div className="flex items-center gap-3">
+					<Spinner size="h-5 w-5" />
+					<span className="text-secondary">
+						Configuring RF region...
+					</span>
+				</div>
+			) : (
+				<div className="flex items-center gap-3">
+					<div>
+						<label
+							htmlFor="rf-region"
+							className="sr-only"
+						>
+							RF Region
+						</label>
+						<select
+							id="rf-region"
+							value={selectedRegion ?? ""}
+							onChange={(e) =>
+								context.setState((prev) => ({
+									...prev,
+									selectedRegion: e.target.value || null,
+									configureStatus: "idle",
+									configureError: null,
+								}))
+							}
+							style={{ width: "16rem" }}
+							className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 py-2 pl-3 pr-10 text-gray-900 dark:text-white focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 sm:text-sm"
+						>
+							<option value="">Select a region...</option>
+							{RF_REGIONS.map((region) => (
+								<option
+									key={region.value}
+									value={region.value}
+								>
+									{region.label}
+								</option>
+							))}
+						</select>
+					</div>
+					<button
+						onClick={handleApply}
+						disabled={!selectedRegion || selectedRegion === context.state.currentRegion}
+						className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-blue-500 dark:hover:bg-blue-400"
+					>
+						Apply
+					</button>
+				</div>
+			)}
+
+			{configureStatus === "success" && (
+				<p className="mt-3 text-sm text-green-600 dark:text-green-400">
+					RF region configured successfully.
+				</p>
+			)}
+
+			{dsk && <SmartStartQRCode dsk={dsk} />}
+		</div>
+	);
+}
+
+function UnconfigurableFirmware({
+	firmwareType,
+}: {
+	firmwareType: string;
+}) {
+	return (
+		<div className="text-center py-4">
+			<div className="text-gray-400 dark:text-gray-500 mb-4">
+				<svg
+					className="w-16 h-16 mx-auto"
+					fill="none"
+					viewBox="0 0 24 24"
+					stroke="currentColor"
+				>
+					<path
+						strokeLinecap="round"
+						strokeLinejoin="round"
+						strokeWidth={1.5}
+						d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"
+					/>
+				</svg>
+			</div>
+			<h3 className="text-lg font-medium text-primary mb-2">
+				No configuration available
+			</h3>
+			<p className="text-gray-600 dark:text-gray-300">
+				{firmwareType} firmware does not support configuration through
+				this tool.
+			</p>
+		</div>
+	);
+}
+
+export default function ConfigureStep({
+	context,
+}: WizardStepProps<ConfigureState>) {
+	const { detectedFirmwareType } = context.state;
+
+	if (detectedFirmwareType === "repeater") {
+		return (
+			<div className="py-8">
+				<RepeaterConfiguration context={context} />
+			</div>
+		);
+	}
+
+	if (detectedFirmwareType != null) {
+		return (
+			<div className="py-8">
+				<UnconfigurableFirmware
+					firmwareType={
+						FIRMWARE_TYPE_LABELS[detectedFirmwareType]
+					}
+				/>
+			</div>
+		);
+	}
+
+	// Unknown or undetected firmware
+	return (
+		<div className="py-8">
+			<div className="text-center py-4">
+				<div className="text-gray-400 dark:text-gray-500 mb-4">
+					<svg
+						className="w-16 h-16 mx-auto"
+						fill="currentColor"
+						viewBox="0 0 20 20"
+					>
+						<path
+							fillRule="evenodd"
+							d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z"
+							clipRule="evenodd"
+						/>
+					</svg>
+				</div>
+				<h3 className="text-lg font-medium text-primary mb-2">
+					Could not detect firmware
+				</h3>
+				<p className="text-gray-600 dark:text-gray-300">
+					Unable to determine the installed firmware type. Make sure the
+					device is connected and running supported firmware.
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/src/wizards/configure/DetectStep.tsx
+++ b/src/wizards/configure/DetectStep.tsx
@@ -1,0 +1,18 @@
+import type { WizardStepProps } from "../../components/Wizard";
+import type { ConfigureState } from "./wizard";
+import Spinner from "../../components/Spinner";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function DetectStep(_props: WizardStepProps<ConfigureState>) {
+	return (
+		<div className="text-center py-8">
+			<Spinner size="h-8 w-8" className="inline-block mb-4" />
+			<h3 className="text-lg font-medium text-primary mb-2">
+				Detecting firmware...
+			</h3>
+			<p className="text-gray-600 dark:text-gray-300">
+				Please do not disconnect the device.
+			</p>
+		</div>
+	);
+}

--- a/src/wizards/configure/DetectStep.tsx
+++ b/src/wizards/configure/DetectStep.tsx
@@ -3,7 +3,7 @@ import type { ConfigureState } from "./wizard";
 import Spinner from "../../components/Spinner";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export default function DetectStep(_props: WizardStepProps<ConfigureState>) {
+export default function DetectStep(_: WizardStepProps<ConfigureState>) {
 	return (
 		<div className="text-center py-8">
 			<Spinner size="h-8 w-8" className="inline-block mb-4" />

--- a/src/wizards/configure/index.ts
+++ b/src/wizards/configure/index.ts
@@ -1,0 +1,1 @@
+export { configureWizardConfig, type ConfigureState } from './wizard';

--- a/src/wizards/configure/wizard.ts
+++ b/src/wizards/configure/wizard.ts
@@ -8,13 +8,11 @@ import type {
 	WizardStepProps,
 } from "../../components/Wizard";
 import type { FirmwareType } from "../../lib/firmware-download";
-import {
-	RFRegion,
-	getLegalPowerlevelMesh,
-	getLegalPowerlevelLR,
-} from "@zwave-js/core/definitions";
+import { applyRepeaterRegion } from "../../lib/regions";
+import { RFRegion } from "@zwave-js/core/definitions";
 import { NabuCasaConfigKey } from "zwave-js/Controller";
 import { getEnumMemberName } from "zwave-js";
+import { getErrorMessage } from "@zwave-js/shared";
 
 export interface RegionOption {
 	value: RFRegion;
@@ -42,19 +40,6 @@ export type ConfigureState = {
 };
 
 export type ConfigureWizardStepProps = WizardStepProps<ConfigureState>;
-
-const CLI_REGION_TO_RF_REGION: Record<string, RFRegion> = {
-	EU: RFRegion.Europe,
-	US: RFRegion.USA,
-	ANZ: RFRegion["Australia/New Zealand"],
-	HK: RFRegion["Hong Kong"],
-	IN: RFRegion.India,
-	IL: RFRegion.Israel,
-	RU: RFRegion.Russia,
-	CN: RFRegion.China,
-	JP: RFRegion.Japan,
-	KR: RFRegion.Korea,
-};
 
 async function handleDetectStepEntry(
 	context: WizardContext<ConfigureState>,
@@ -158,54 +143,17 @@ export async function applyRepeaterRegionConfiguration(
 	}));
 
 	try {
-		const setSuccess = await context.zwaveBinding.setRegion(selectedRegion);
-		if (!setSuccess) {
+		const result = await applyRepeaterRegion(
+			context.zwaveBinding,
+			selectedRegion,
+		);
+		if (result !== true) {
 			context.setState((prev) => ({
 				...prev,
 				configureStatus: "error",
-				configureError: "Failed to set RF region. Please try again.",
+				configureError: result,
 			}));
 			return false;
-		}
-
-		// Wait for ZWA-2 to reboot
-		const { wait } = await import("alcalzone-shared/async");
-		await wait(1000);
-
-		// Verify region
-		const confirmedRegion = await context.zwaveBinding.getRegion();
-		if (confirmedRegion !== selectedRegion) {
-			context.setState((prev) => ({
-				...prev,
-				configureStatus: "error",
-				configureError: `Region verification failed. Expected "${selectedRegion}" but got "${confirmedRegion ?? "unknown"}".`,
-			}));
-			return false;
-		}
-
-		// Configure power levels if legal limits are known for this region
-		const rfRegion = CLI_REGION_TO_RF_REGION[selectedRegion];
-		if (rfRegion != null) {
-			const meshLimit = getLegalPowerlevelMesh(rfRegion);
-			const lrLimit = getLegalPowerlevelLR(rfRegion);
-
-			if (meshLimit != null || lrLimit != null) {
-				const current = await context.zwaveBinding.getPowerlevel();
-				if (current) {
-					const newMeshMax =
-						meshLimit != null
-							? meshLimit * 10
-							: current.txPowerMax;
-					const newLRMax =
-						lrLimit != null ? lrLimit * 10 : current.txPowerMaxLR;
-
-					await context.zwaveBinding.setPowerlevel(
-						newMeshMax,
-						current.txPowerAdjust,
-						newLRMax,
-					);
-				}
-			}
 		}
 
 		context.setState((prev) => ({
@@ -218,7 +166,7 @@ export async function applyRepeaterRegionConfiguration(
 		context.setState((prev) => ({
 			...prev,
 			configureStatus: "error",
-			configureError: `Unexpected error: ${error}`,
+			configureError: `Unexpected error: ${getErrorMessage(error)}`,
 		}));
 		return false;
 	}
@@ -261,7 +209,7 @@ export async function applyControllerRegionConfiguration(
 		context.setState((prev) => ({
 			...prev,
 			configureStatus: "error",
-			configureError: `Unexpected error: ${error}`,
+			configureError: `Unexpected error: ${getErrorMessage(error)}`,
 		}));
 		return false;
 	}

--- a/src/wizards/configure/wizard.ts
+++ b/src/wizards/configure/wizard.ts
@@ -1,0 +1,220 @@
+import { Cog6ToothIcon } from "@heroicons/react/24/outline";
+import ConnectStep from "../../components/steps/ConnectStep";
+import DetectStep from "./DetectStep";
+import ConfigureStep from "./ConfigureStep";
+import type {
+	WizardConfig,
+	WizardContext,
+	WizardStepProps,
+} from "../../components/Wizard";
+import type { FirmwareType } from "../../lib/firmware-download";
+import {
+	RFRegion,
+	getLegalPowerlevelMesh,
+	getLegalPowerlevelLR,
+} from "@zwave-js/core/definitions";
+
+export type ConfigureState = {
+	// Detection phase
+	detectionState: "pending" | "detecting" | "done";
+	detectedFirmwareType: FirmwareType | null;
+	// Repeater configuration
+	currentRegion: string | null;
+	selectedRegion: string | null;
+	configureStatus: "idle" | "configuring" | "success" | "error";
+	configureError: string | null;
+	dsk: string | null;
+};
+
+export type ConfigureWizardStepProps = WizardStepProps<ConfigureState>;
+
+const CLI_REGION_TO_RF_REGION: Record<string, RFRegion> = {
+	EU: RFRegion.Europe,
+	US: RFRegion.USA,
+	ANZ: RFRegion["Australia/New Zealand"],
+	HK: RFRegion["Hong Kong"],
+	IN: RFRegion.India,
+	IL: RFRegion.Israel,
+	RU: RFRegion.Russia,
+	CN: RFRegion.China,
+	JP: RFRegion.Japan,
+	KR: RFRegion.Korea,
+};
+
+async function handleDetectStepEntry(
+	context: WizardContext<ConfigureState>,
+): Promise<void> {
+	if (context.state.detectionState !== "pending") return;
+
+	context.setState((prev) => ({ ...prev, detectionState: "detecting" }));
+
+	if (!context.zwaveBinding) {
+		context.setState((prev) => ({ ...prev, detectionState: "done" }));
+		context.goToStep("Configure");
+		return;
+	}
+
+	try {
+		const detected = await context.zwaveBinding.detectFirmwareType();
+		const firmwareType = detected === "unknown" ? null : detected;
+
+		let dsk: string | null = null;
+		let currentRegion: string | null = null;
+
+		// For repeater firmware, read the current region and DSK.
+		// These must be sequential — both use CLI commands over the
+		// same serial connection and would mix up responses in parallel.
+		if (firmwareType === "repeater") {
+			dsk = await context.zwaveBinding.getDSK();
+			currentRegion = await context.zwaveBinding.getRegion();
+		}
+
+		context.setState((prev) => ({
+			...prev,
+			detectedFirmwareType: firmwareType,
+			detectionState: "done",
+			dsk,
+			currentRegion,
+			selectedRegion: currentRegion,
+		}));
+	} catch {
+		context.setState((prev) => ({ ...prev, detectionState: "done" }));
+	}
+
+	context.goToStep("Configure");
+}
+
+export async function applyRegionConfiguration(
+	context: WizardContext<ConfigureState>,
+): Promise<boolean> {
+	const { selectedRegion } = context.state;
+
+	if (!selectedRegion || !context.zwaveBinding) {
+		return false;
+	}
+
+	context.setState((prev) => ({
+		...prev,
+		configureStatus: "configuring",
+		configureError: null,
+	}));
+
+	try {
+		const setSuccess = await context.zwaveBinding.setRegion(selectedRegion);
+		if (!setSuccess) {
+			context.setState((prev) => ({
+				...prev,
+				configureStatus: "error",
+				configureError: "Failed to set RF region. Please try again.",
+			}));
+			return false;
+		}
+
+		// Wait for ZWA-2 to reboot
+		const { wait } = await import("alcalzone-shared/async");
+		await wait(1000);
+
+		// Verify region
+		const confirmedRegion = await context.zwaveBinding.getRegion();
+		if (confirmedRegion !== selectedRegion) {
+			context.setState((prev) => ({
+				...prev,
+				configureStatus: "error",
+				configureError: `Region verification failed. Expected "${selectedRegion}" but got "${confirmedRegion ?? "unknown"}".`,
+			}));
+			return false;
+		}
+
+		// Configure power levels if legal limits are known for this region
+		const rfRegion = CLI_REGION_TO_RF_REGION[selectedRegion];
+		if (rfRegion != null) {
+			const meshLimit = getLegalPowerlevelMesh(rfRegion);
+			const lrLimit = getLegalPowerlevelLR(rfRegion);
+
+			if (meshLimit != null || lrLimit != null) {
+				const current = await context.zwaveBinding.getPowerlevel();
+				if (current) {
+					const newMeshMax =
+						meshLimit != null
+							? meshLimit * 10
+							: current.txPowerMax;
+					const newLRMax =
+						lrLimit != null ? lrLimit * 10 : current.txPowerMaxLR;
+
+					await context.zwaveBinding.setPowerlevel(
+						newMeshMax,
+						current.txPowerAdjust,
+						newLRMax,
+					);
+				}
+			}
+		}
+
+		context.setState((prev) => ({
+			...prev,
+			configureStatus: "success",
+			currentRegion: selectedRegion,
+		}));
+		return true;
+	} catch (error) {
+		context.setState((prev) => ({
+			...prev,
+			configureStatus: "error",
+			configureError: `Unexpected error: ${error}`,
+		}));
+		return false;
+	}
+}
+
+export const configureWizardConfig: WizardConfig<ConfigureState> = {
+	id: "configure",
+	title: "Configure ZWA-2",
+	description:
+		"View and change the RF region and other settings on your ZWA-2.",
+	icon: Cog6ToothIcon,
+	iconForeground: "text-purple-700 dark:text-purple-400",
+	iconBackground: "bg-purple-50 dark:bg-purple-500/10",
+	createInitialState: () => ({
+		detectionState: "pending",
+		detectedFirmwareType: null,
+		currentRegion: null,
+		selectedRegion: null,
+		configureStatus: "idle",
+		configureError: null,
+		dsk: null,
+	}),
+	steps: [
+		{
+			name: "Connect",
+			component: ConnectStep<ConfigureState>,
+			navigationButtons: {
+				next: {
+					label: "Next",
+					disabled: (context) =>
+						context.connectionState.status !== "connected",
+					beforeNavigate: async (context) => {
+						return await context.afterConnect();
+					},
+				},
+				cancel: {
+					label: "Cancel",
+				},
+			},
+		},
+		{
+			name: "Detect",
+			component: DetectStep,
+			onEnter: handleDetectStepEntry,
+		},
+		{
+			name: "Configure",
+			component: ConfigureStep,
+			isFinal: true,
+			navigationButtons: {
+				next: {
+					label: "Finish",
+				},
+			},
+		},
+	],
+};

--- a/src/wizards/configure/wizard.ts
+++ b/src/wizards/configure/wizard.ts
@@ -13,17 +13,32 @@ import {
 	getLegalPowerlevelMesh,
 	getLegalPowerlevelLR,
 } from "@zwave-js/core/definitions";
+import { NabuCasaConfigKey } from "zwave-js/Controller";
+import { getEnumMemberName } from "zwave-js";
+
+export interface RegionOption {
+	value: RFRegion;
+	label: string;
+	disabled: boolean;
+}
 
 export type ConfigureState = {
 	// Detection phase
 	detectionState: "pending" | "detecting" | "done";
 	detectedFirmwareType: FirmwareType | null;
-	// Repeater configuration
-	currentRegion: string | null;
-	selectedRegion: string | null;
+	// Region configuration (shared between repeater and controller)
+	currentRegion: string | RFRegion | null;
+	selectedRegion: string | RFRegion | null;
 	configureStatus: "idle" | "configuring" | "success" | "error";
 	configureError: string | null;
+	// Repeater-specific
 	dsk: string | null;
+	// Controller-specific
+	supportedRegions: RegionOption[];
+	ledEnabled: boolean | null;
+	tiltIndicatorEnabled: boolean | null;
+	togglingLed: boolean;
+	togglingTilt: boolean;
 };
 
 export type ConfigureWizardStepProps = WizardStepProps<ConfigureState>;
@@ -59,14 +74,54 @@ async function handleDetectStepEntry(
 		const firmwareType = detected === "unknown" ? null : detected;
 
 		let dsk: string | null = null;
-		let currentRegion: string | null = null;
+		let currentRegion: string | RFRegion | null = null;
+		let supportedRegions: RegionOption[] = [];
+		let ledEnabled: boolean | null = null;
+		let tiltIndicatorEnabled: boolean | null = null;
 
-		// For repeater firmware, read the current region and DSK.
-		// These must be sequential — both use CLI commands over the
-		// same serial connection and would mix up responses in parallel.
 		if (firmwareType === "repeater") {
+			// These must be sequential — both use CLI commands over the
+			// same serial connection and would mix up responses in parallel.
 			dsk = await context.zwaveBinding.getDSK();
 			currentRegion = await context.zwaveBinding.getRegion();
+		} else if (firmwareType === "controller") {
+			const ctrl = context.zwaveBinding.controller;
+			if (ctrl) {
+				// Read supported regions
+				const regions = ctrl.getSupportedRFRegions();
+				if (regions) {
+					supportedRegions = regions
+						.map((region) => ({
+							value: region,
+							label: getEnumMemberName(RFRegion, region),
+							disabled:
+								region === RFRegion.Unknown ||
+								region === RFRegion["Default (EU)"],
+						}))
+						.sort((a, b) => a.label.localeCompare(b.label));
+				}
+
+				// Read current region
+				currentRegion = await ctrl.getRFRegion();
+
+				// Read LED state and tilt indicator
+				const nabuCasa = ctrl.proprietary["Nabu Casa"];
+				if (nabuCasa) {
+					try {
+						ledEnabled = await nabuCasa.getLEDBinary();
+					} catch {
+						// LED control not supported
+					}
+					try {
+						const val = await nabuCasa.getConfig(
+							NabuCasaConfigKey.EnableTiltIndicator,
+						);
+						tiltIndicatorEnabled = val === 1;
+					} catch {
+						// Tilt indicator not supported
+					}
+				}
+			}
 		}
 
 		context.setState((prev) => ({
@@ -76,6 +131,9 @@ async function handleDetectStepEntry(
 			dsk,
 			currentRegion,
 			selectedRegion: currentRegion,
+			supportedRegions,
+			ledEnabled,
+			tiltIndicatorEnabled,
 		}));
 	} catch {
 		context.setState((prev) => ({ ...prev, detectionState: "done" }));
@@ -84,12 +142,12 @@ async function handleDetectStepEntry(
 	context.goToStep("Configure");
 }
 
-export async function applyRegionConfiguration(
+export async function applyRepeaterRegionConfiguration(
 	context: WizardContext<ConfigureState>,
 ): Promise<boolean> {
 	const { selectedRegion } = context.state;
 
-	if (!selectedRegion || !context.zwaveBinding) {
+	if (!selectedRegion || typeof selectedRegion !== "string" || !context.zwaveBinding) {
 		return false;
 	}
 
@@ -166,14 +224,100 @@ export async function applyRegionConfiguration(
 	}
 }
 
+export async function applyControllerRegionConfiguration(
+	context: WizardContext<ConfigureState>,
+): Promise<boolean> {
+	const { selectedRegion } = context.state;
+	const ctrl = context.zwaveBinding?.controller;
+
+	if (selectedRegion == null || typeof selectedRegion !== "number" || !ctrl) {
+		return false;
+	}
+
+	context.setState((prev) => ({
+		...prev,
+		configureStatus: "configuring",
+		configureError: null,
+	}));
+
+	try {
+		const success = await ctrl.setRFRegion(selectedRegion);
+		if (!success) {
+			context.setState((prev) => ({
+				...prev,
+				configureStatus: "error",
+				configureError: "Failed to set RF region. Please try again.",
+			}));
+			return false;
+		}
+
+		context.setState((prev) => ({
+			...prev,
+			configureStatus: "success",
+			currentRegion: selectedRegion,
+		}));
+		return true;
+	} catch (error) {
+		context.setState((prev) => ({
+			...prev,
+			configureStatus: "error",
+			configureError: `Unexpected error: ${error}`,
+		}));
+		return false;
+	}
+}
+
+export async function toggleLED(
+	context: WizardContext<ConfigureState>,
+	enabled: boolean,
+): Promise<void> {
+	const nabuCasa = context.zwaveBinding?.controller?.proprietary["Nabu Casa"];
+	if (!nabuCasa) return;
+
+	context.setState((prev) => ({ ...prev, togglingLed: true }));
+	try {
+		await nabuCasa.setLEDBinary(enabled);
+		context.setState((prev) => ({
+			...prev,
+			ledEnabled: enabled,
+			togglingLed: false,
+		}));
+	} catch {
+		context.setState((prev) => ({ ...prev, togglingLed: false }));
+	}
+}
+
+export async function toggleTiltIndicator(
+	context: WizardContext<ConfigureState>,
+	enabled: boolean,
+): Promise<void> {
+	const nabuCasa = context.zwaveBinding?.controller?.proprietary["Nabu Casa"];
+	if (!nabuCasa) return;
+
+	context.setState((prev) => ({ ...prev, togglingTilt: true }));
+	try {
+		await nabuCasa.setConfig(
+			NabuCasaConfigKey.EnableTiltIndicator,
+			enabled ? 1 : 0,
+		);
+		context.setState((prev) => ({
+			...prev,
+			tiltIndicatorEnabled: enabled,
+			togglingTilt: false,
+		}));
+	} catch {
+		context.setState((prev) => ({ ...prev, togglingTilt: false }));
+	}
+}
+
 export const configureWizardConfig: WizardConfig<ConfigureState> = {
 	id: "configure",
 	title: "Configure ZWA-2",
 	description:
 		"View and change the RF region and other settings on your ZWA-2.",
 	icon: Cog6ToothIcon,
-	iconForeground: "text-purple-700 dark:text-purple-400",
-	iconBackground: "bg-purple-50 dark:bg-purple-500/10",
+	iconForeground: "text-green-700 dark:text-green-400",
+	iconBackground: "bg-green-50 dark:bg-green-500/10",
 	createInitialState: () => ({
 		detectionState: "pending",
 		detectedFirmwareType: null,
@@ -182,6 +326,11 @@ export const configureWizardConfig: WizardConfig<ConfigureState> = {
 		configureStatus: "idle",
 		configureError: null,
 		dsk: null,
+		supportedRegions: [],
+		ledEnabled: null,
+		tiltIndicatorEnabled: null,
+		togglingLed: false,
+		togglingTilt: false,
 	}),
 	steps: [
 		{

--- a/src/wizards/index.ts
+++ b/src/wizards/index.ts
@@ -1,4 +1,5 @@
 import { installFirmwareWizardConfig } from "./install-firmware";
+import { configureWizardConfig } from "./configure";
 import {
 	updateESPFirmwareWizardConfig,
 	// updateESPBridgeWizardConfig,
@@ -11,6 +12,7 @@ import { recoverAdapterWizardConfig } from "./recover-adapter";
 export const wizards = [
 	installFirmwareWizardConfig,
 	updateESPFirmwareWizardConfig,
+	configureWizardConfig,
 	//   updateFirmwareWizardConfig,
 	recoverAdapterWizardConfig,
 	// updateESPBridgeWizardConfig,

--- a/src/wizards/install-firmware/ConfigureStep.tsx
+++ b/src/wizards/install-firmware/ConfigureStep.tsx
@@ -2,19 +2,7 @@ import type { WizardStepProps } from "../../components/Wizard";
 import type { InstallFirmwareState } from "./wizard";
 import Spinner from "../../components/Spinner";
 import Alert from "../../components/Alert";
-
-const RF_REGIONS = [
-	{ label: "Europe", value: "EU" },
-	{ label: "USA", value: "US" },
-	{ label: "Australia/New Zealand", value: "ANZ" },
-	{ label: "Hong Kong", value: "HK" },
-	{ label: "India", value: "IN" },
-	{ label: "Israel", value: "IL" },
-	{ label: "Russia", value: "RU" },
-	{ label: "China", value: "CN" },
-	{ label: "Japan", value: "JP" },
-	{ label: "Korea", value: "KR" },
-] as const;
+import { RF_REGIONS } from "../../lib/regions";
 
 export default function ConfigureStep({
 	context,

--- a/src/wizards/install-firmware/FileSelectStep.tsx
+++ b/src/wizards/install-firmware/FileSelectStep.tsx
@@ -1,13 +1,8 @@
 import type { WizardStepProps } from '../../components/Wizard';
-import type { InstallFirmwareState, FirmwareOption, FirmwareType } from './wizard';
+import type { InstallFirmwareState, FirmwareOption } from './wizard';
 import { firmwareTypeFromOption, needsDataLossWarning } from './wizard';
 import Spinner from '../../components/Spinner';
-
-const FIRMWARE_TYPE_LABELS: Record<FirmwareType, string> = {
-  controller: "Controller",
-  repeater: "Repeater",
-  zniffer: "Zniffer",
-};
+import { FIRMWARE_TYPE_LABELS } from '../../lib/regions';
 
 const firmwareOptions: Array<{ value: FirmwareOption; label: string; description: string; experimental?: boolean }> = [
   {

--- a/src/wizards/install-firmware/SummaryStep.tsx
+++ b/src/wizards/install-firmware/SummaryStep.tsx
@@ -1,43 +1,8 @@
-import { useEffect, useState } from 'react';
 import type { WizardStepProps } from '../../components/Wizard';
 import type { InstallFirmwareState } from './wizard';
 import { firmwareTypeFromOption } from './wizard';
-import { generateRepeaterQRCode } from '../../lib/qr-code';
-
-const FIRMWARE_TYPE_LABELS = {
-  controller: "controller",
-  repeater: "repeater",
-  zniffer: "Zniffer",
-} as const;
-
-function SmartStartQRCode({ dsk }: { dsk: string }) {
-  const [svgMarkup, setSvgMarkup] = useState<string | null>(null);
-
-  useEffect(() => {
-    generateRepeaterQRCode(dsk).then(setSvgMarkup).catch((err) => {
-      console.error("Failed to generate QR code:", err);
-    });
-  }, [dsk]);
-
-  if (!svgMarkup) return null;
-
-  return (
-    <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg">
-      <p className="font-medium text-blue-800 dark:text-blue-300 mb-3">
-        Scan QR code to join via SmartStart:
-      </p>
-      <div className="flex flex-col items-center">
-        <div
-          className="w-64 bg-white rounded-lg overflow-hidden [&>svg]:w-full [&>svg]:h-auto [&>svg]:block"
-          dangerouslySetInnerHTML={{ __html: svgMarkup }}
-        />
-        <p className="mt-3 font-mono text-sm text-blue-900 dark:text-blue-100 select-all break-all">
-          DSK: <span className="font-bold underline">{dsk.slice(0, 5)}</span>{dsk.slice(5)}
-        </p>
-      </div>
-    </div>
-  );
-}
+import SmartStartQRCode from '../../components/SmartStartQRCode';
+import { FIRMWARE_TYPE_LABELS } from '../../lib/regions';
 
 export default function SummaryStep({ context }: WizardStepProps<InstallFirmwareState>) {
   const { flashResult, errorMessage, selectedFirmware } = context.state;

--- a/src/wizards/install-firmware/wizard.ts
+++ b/src/wizards/install-firmware/wizard.ts
@@ -14,11 +14,7 @@ import {
 	type FirmwareType,
 } from "../../lib/firmware-download";
 import { DriverMode } from "zwave-js";
-import {
-	RFRegion,
-	getLegalPowerlevelMesh,
-	getLegalPowerlevelLR,
-} from "@zwave-js/core/definitions";
+import { applyRepeaterRegion } from "../../lib/regions";
 import { type BytesView } from "@zwave-js/shared";
 
 export type { FirmwareType } from "../../lib/firmware-download";
@@ -113,19 +109,6 @@ async function handleFileSelectStepEntry(
 	}
 }
 
-const CLI_REGION_TO_RF_REGION: Record<string, RFRegion> = {
-	EU: RFRegion.Europe,
-	US: RFRegion.USA,
-	ANZ: RFRegion["Australia/New Zealand"],
-	HK: RFRegion["Hong Kong"],
-	IN: RFRegion.India,
-	IL: RFRegion.Israel,
-	RU: RFRegion.Russia,
-	CN: RFRegion.China,
-	JP: RFRegion.Japan,
-	KR: RFRegion.Korea,
-};
-
 async function handleConfigureStepEntry(
 	context: WizardContext<InstallFirmwareState>,
 ): Promise<void> {
@@ -161,7 +144,6 @@ async function handleConfigureBeforeNavigate(
 		return false;
 	}
 
-	// Show spinner
 	context.setState((prev) => ({
 		...prev,
 		configureStatus: "configuring",
@@ -169,59 +151,17 @@ async function handleConfigureBeforeNavigate(
 	}));
 
 	try {
-		const setSuccess = await context.zwaveBinding.setRegion(selectedRegion);
-		if (!setSuccess) {
+		const result = await applyRepeaterRegion(
+			context.zwaveBinding,
+			selectedRegion,
+		);
+		if (result !== true) {
 			context.setState((prev) => ({
 				...prev,
 				configureStatus: "error",
-				configureError: "Failed to set RF region. Please try again.",
+				configureError: result,
 			}));
 			return false;
-		}
-
-		// Wait for ZWA-2 to reboot
-		const { wait } = await import("alcalzone-shared/async");
-		await wait(1000);
-
-		// Verify region
-		const confirmedRegion = await context.zwaveBinding.getRegion();
-		if (confirmedRegion !== selectedRegion) {
-			context.setState((prev) => ({
-				...prev,
-				configureStatus: "error",
-				configureError: `Region verification failed. Expected "${selectedRegion}" but got "${confirmedRegion ?? "unknown"}".`,
-			}));
-			return false;
-		}
-
-		// Configure power levels if legal limits are known for this region
-		const rfRegion = CLI_REGION_TO_RF_REGION[selectedRegion];
-		if (rfRegion != null) {
-			const meshLimit = getLegalPowerlevelMesh(rfRegion);
-			const lrLimit = getLegalPowerlevelLR(rfRegion);
-
-			if (meshLimit != null || lrLimit != null) {
-				// Get current power levels to preserve the adjust value
-				const current =
-					await context.zwaveBinding.getPowerlevel();
-				if (current) {
-					// Z-Wave JS returns dBm, CLI uses deci-dBm
-					const newMeshMax =
-						meshLimit != null
-							? meshLimit * 10
-							: current.txPowerMax;
-					const newLRMax =
-						lrLimit != null
-							? lrLimit * 10
-							: current.txPowerMaxLR;
-
-					await context.zwaveBinding.setPowerlevel(
-						newMeshMax,
-						current.txPowerAdjust,
-						newLRMax,
-					);
-				}
-			}
 		}
 
 		context.setState((prev) => ({


### PR DESCRIPTION
This PR adds a firmware-specific configuration wizard. On the repeater firmware this lets users re-configure the RF region and show the QR code again:
<img width="1057" height="518" alt="grafik" src="https://github.com/user-attachments/assets/881db47d-6572-46a0-971f-b12198875c8f" />
